### PR TITLE
cli: enable status sub command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,34 @@
-fn main() {
-    println!("Hello, world!");
+use clap::{Parser, Subcommand, arg, command};
+use log::debug;
+
+#[derive(Parser, Debug)]
+#[command(name = "fpga")]
+#[command(bin_name = "fpga")]
+struct Cli {
+    #[arg(
+        long = "handle",
+        help = r#"fpga device handle to be used for operations.
+Default value for this option is calculated in runtime and application
+picks first available fpga in the system (under /sys/class/fpga_manager).
+        "#
+    )]
+    handle: Option<String>,
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    Status,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+    let cli = Cli::parse();
+    debug!("parsed cli command with {cli:?}");
+    match cli.command {
+        Commands::Status => {
+            todo!()
+        }
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,13 +5,10 @@ use log::debug;
 #[command(name = "fpga")]
 #[command(bin_name = "fpga")]
 struct Cli {
-    #[arg(
-        long = "handle",
-        help = r#"fpga device handle to be used for operations.
-Default value for this option is calculated in runtime and application
-picks first available fpga in the system (under /sys/class/fpga_manager).
-        "#
-    )]
+    /// fpga device `HANDLE` to be used for the operations.
+    /// Default value for this option is calculated in runtime and the application
+    /// picks the first available fpga in the system (under /sys/class/fpga_manager)
+    #[arg(long = "handle")]
     handle: Option<String>,
     #[command(subcommand)]
     command: Commands,
@@ -19,6 +16,7 @@ picks first available fpga in the system (under /sys/class/fpga_manager).
 
 #[derive(Subcommand, Debug)]
 enum Commands {
+    /// Get the status information for the given device handle
     Status,
 }
 


### PR DESCRIPTION
Enabled cli application and status subcommand using clap.
This makes `fpga [--handle=<device_handle>] status` syntax available.

Please do not merge this pr before 
* __->__ #20 