### PR TITLE
cli: add load command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,9 +15,33 @@ struct Cli {
 }
 
 #[derive(Subcommand, Debug)]
+enum LoadSubcommand {
+    /// Load overlay into the system
+    Overlay {
+        /// Overlay `FILE` to be loaded (typically .dtbo)
+        file: String,
+
+        /// `HANDLE` for the overlay directory which will be created
+        /// under "/sys/kernel/config/device-tree/overlays"
+        #[arg(long = "handle")]
+        handle: Option<String>,
+    },
+    /// Load bitstream into the system
+    Bitstream {
+        /// Bitstream `FILE` to be loaded (typically .bit.bin)
+        file: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 enum Commands {
     /// Get the status information for the given device handle
     Status,
+    /// Load a bitstream or an overlay for the given device handle
+    Load {
+        #[command(subcommand)]
+        command: LoadSubcommand,
+    },
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -28,5 +52,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Status => {
             todo!()
         }
+        Commands::Load { .. } => todo!(),
     }
 }


### PR DESCRIPTION
This enables below usage:
`fpga [--handle=<device_handle>] load ( (overlay <file> [--handle=<handle>]) | (bitstream <file>) )`

User may use `fpga load overlay` command to load dtbo and firmware that
it states into the system. They can also use `fpga load bitstream` to
only load bitstream into the system.

In some cases, users dont need to have dtbo to be applied to system but
they can choose to only load bitstream.

**Please do not merge before PRs below:**
- __->__ #21 
