### PR TITLE
platforms: dbus: implement a configuration system for system paths

### DIFF
--- a/.git_components.yaml
+++ b/.git_components.yaml
@@ -30,3 +30,6 @@ cli:
 docs:
   owners:
     - artiepoole
+config:
+  owners:
+    - artiepoole

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,8 +324,10 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "log",
+ "serde",
  "thiserror",
  "tokio",
+ "toml",
  "zbus",
 ]
 
@@ -709,6 +711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,21 +831,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.9"
+name = "toml"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.25"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1011,9 +1046,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ env_logger = "0.11.8"
 tokio = { version = "1.44.2", features = ["full"] }
 zbus = { version = "5.5.0", default-features = false, features = ["tokio"] }
 thiserror = "2.0.12"
+toml = "0.8.23"
+serde = { version = "1.0.219", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -87,3 +87,15 @@ sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.c
 
 sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control RemoveOverlay ss "fpga0" "fpga0" 
 ```
+
+### Configure
+
+```
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetConfigFsPrefix
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetFirmwarePrefix
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetSysFsPrefix
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetConfigFsPrefix s "/sys/kernel/config/device-tree/overlays/"
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetFirmwarePrefix s "/lib/firmware/"
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetSysFsPrefix s "/sys/class/fpga_manager/"
+```

--- a/README.md
+++ b/README.md
@@ -39,12 +39,21 @@ sudo cp ./data/dbus/com.canonical.fpgad.conf /etc/dbus-1/system.d/
 
 ```
 sudo mkdir -p /etc/fpgad/
-sudo cp ./data/config.toml /etc/fpgad/
+sudo cp ./data/config.toml /etc/fpgad/ 
+sudo mkdir -p /usr/lib/fpgad/
+sudo cp ./data/config.toml /usr/lib/fpgad/
 ```
+
+During install, the /etc/fpgad/ version doesn't need to exist, so can be created blank,
+not copied in or be a copy of the `/usr/lib` version.
+
+The `/usr/lib/` variant should be created during install and should contain a comment like
+"DO NO EDIT THIS FILE USE  `/etc/fpgad/config.toml` FOR USER SPECIFIED OVERRIDES"
 
 ### `config.toml` location
 
-The config file must be stored in `/etc/fpgad` (or `$snap/etc/fpgad/` or similar path adjusted by snap layouts) and
+The user provided config file must be stored in `/etc/fpgad` (or `$snap/etc/fpgad/` or similar path adjusted by snap
+layouts) and
 must be called `config.toml`
 
 ## `config.toml` syntax

--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.c
 ### Configure
 
 ```
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetConfigFsPrefix
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetFirmwarePrefix
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetSysFsPrefix
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetOverlayControlDir
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetFirmwareSourceDir
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetFpgaManagersDir
 
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetConfigFsPrefix s "/sys/kernel/config/device-tree/overlays/"
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetFirmwarePrefix s "/lib/firmware/"
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetSysFsPrefix s "/sys/class/fpga_manager/"
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetOverlayControlDir s "/sys/kernel/config/device-tree/overlays/"
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetFirmwareSourceDir s "/lib/firmware/"
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetFpgaManagersDir s "/sys/class/fpga_manager/"
 ```

--- a/README.md
+++ b/README.md
@@ -27,10 +27,45 @@ It should be clear to see, then, that compromising the device tree is very power
 sudo RUST_LOG=trace RUST_BACKTRACE=full ./target/debug/fpgad
 ```
 
-# Configure DBUS:
+# Configure DBUS
 
 ```
 sudo cp ./data/dbus/com.canonical.fpgad.conf /etc/dbus-1/system.d/
+```
+
+# Configuration File
+
+### To use the provided `config.toml`
+
+```
+sudo mkdir -p /etc/fpgad/
+sudo cp ./data/config.toml /etc/fpgad/
+```
+
+### `config.toml` location
+
+The config file must be stored in `/etc/fpgad` (or `$snap/etc/fpgad/` or similar path adjusted by snap layouts) and
+must be called `config.toml`
+
+## `config.toml` syntax
+
+Any unspecified values will default to hardcoded defaults, as described in the table below.
+
+### `[system_paths]` section:
+
+| Key                | Description                                                                                                                       | Default                                      |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
+| `config_fs_prefix` | The location to which configfs is mounted. This is used to control device tree overlays                                           | `"/sys/kernel/config/device-tree/overlays/"` |
+| `firmware_prefix`  | The directory within which the firmware subsystem and overlayfs subssystem search relative to when loading bitstreams or overlays | `"/lib/firmware/"`                           |
+| `sys_fs_prefix`    | The location of the fpga_manager device folder which contains, for example, `fpga0`.                                              | `"/sys/class/fpga_manager/"`                 |
+
+### Example `config.toml`
+
+```toml
+[system_paths]
+config_fs_prefix = "/sys/kernel/config/device-tree/overlays/"
+firmware_prefix = "/lib/firmware/"
+sys_fs_prefix = "/sys/class/fpga_manager/"
 ```
 
 # Typical control sequence

--- a/README.md
+++ b/README.md
@@ -62,19 +62,19 @@ Any unspecified values will default to hardcoded defaults, as described in the t
 
 ### `[system_paths]` section:
 
-| Key                | Description                                                                                                                       | Default                                      |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
-| `config_fs_prefix` | The location to which configfs is mounted. This is used to control device tree overlays                                           | `"/sys/kernel/config/device-tree/overlays/"` |
-| `firmware_prefix`  | The directory within which the firmware subsystem and overlayfs subssystem search relative to when loading bitstreams or overlays | `"/lib/firmware/"`                           |
-| `sys_fs_prefix`    | The location of the fpga_manager device folder which contains, for example, `fpga0`.                                              | `"/sys/class/fpga_manager/"`                 |
+| Key                   | Description                                                                                                                      | Default                                      |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
+| `overlay_control_dir` | The location to which configfs is mounted. This is used to control device tree overlays                                          | `"/sys/kernel/config/device-tree/overlays/"` |
+| `firmware_source_dir` | The directory within which the firmware subsystem and overlayfs subsystem search relative to when loading bitstreams or overlays | `"/lib/firmware/"`                           |
+| `fpga_managers_dir`   | The location of the fpga_manager device folder which contains, for example, `fpga0`.                                             | `"/sys/class/fpga_manager/"`                 |
 
 ### Example `config.toml`
 
 ```toml
 [system_paths]
-config_fs_prefix = "/sys/kernel/config/device-tree/overlays/"
-firmware_prefix = "/lib/firmware/"
-sys_fs_prefix = "/sys/class/fpga_manager/"
+overlay_control_dir = "/sys/kernel/config/device-tree/overlays/"
+firmware_source_dir = "/lib/firmware/"
+fpga_managers_dir = "/sys/class/fpga_manager/"
 ```
 
 # Typical control sequence

--- a/data/config.toml
+++ b/data/config.toml
@@ -1,4 +1,4 @@
 [system_paths]
-config_fs_prefix = "/sys/kernel/config/device-tree/overlays/"
-firmware_prefix = "/lib/firmware/"
-sys_fs_prefix = "/sys/class/fpga_manager/"
+overlay_control_dir = "/sys/kernel/config/device-tree/overlays/"
+firmware_source_dir = "/lib/firmware/"
+fpga_managers_dir = "/sys/class/fpga_manager/"

--- a/data/config.toml
+++ b/data/config.toml
@@ -1,0 +1,4 @@
+[system_paths]
+config_fs_prefix = "/sys/kernel/config/device-tree/overlays/"
+firmware_prefix = "/lib/firmware/"
+sys_fs_prefix = "/sys/class/fpga_manager/"

--- a/data/dbus/com.canonical.fpgad.conf
+++ b/data/dbus/com.canonical.fpgad.conf
@@ -8,6 +8,7 @@
     <allow own="com.canonical.fpgad"/>
 
     <allow send_destination="com.canonical.fpgad"/>
+    <allow send_interface="com.canonical.fpgad.configure"/>
     <allow send_interface="com.canonical.fpgad.control"/>
     <allow send_interface="com.canonical.fpgad.status"/>
   </policy>
@@ -15,6 +16,7 @@
   <!-- Unprivileged interface -->
   <policy context="default">
     <allow send_destination="com.canonical.fpgad"/>
+    <allow send_interface="com.canonical.fpgad.configure"/>
     <allow send_interface="com.canonical.fpgad.status"/>
     <deny send_interface="com.canonical.fpgad.control"/>
   </policy>

--- a/src/comm/dbus/interfaces.rs
+++ b/src/comm/dbus/interfaces.rs
@@ -47,13 +47,13 @@ impl StatusInterface {
     async fn get_fpga_state(&self, device_handle: &str) -> Result<String, fdo::Error> {
         trace!("get_fpga_state called with name: {device_handle}");
         validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle).fpga(device_handle)?.state()?)
+        Ok(new_platform(device_handle)?.fpga(device_handle)?.state()?)
     }
 
     async fn get_fpga_flags(&self, device_handle: &str) -> Result<String, fdo::Error> {
         trace!("get_fpga_flags called with name: {device_handle}");
         validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle)
+        Ok(new_platform(device_handle)?
             .fpga(device_handle)?
             .flags()
             .map(|flags| flags.to_string())?)
@@ -69,7 +69,7 @@ impl StatusInterface {
              {overlay_handle}"
         );
         validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle)
+        Ok(new_platform(device_handle)?
             .overlay_handler(overlay_handle)?
             .status()?)
     }
@@ -84,7 +84,7 @@ impl ControlInterface {
     ) -> Result<String, fdo::Error> {
         trace!("set_fpga_flags called with name: {device_handle} and flags: {flags}");
         validate_device_handle(device_handle)?;
-        new_platform(device_handle)
+        new_platform(device_handle)?
             .fpga(device_handle)?
             .set_flags(flags)?;
         Ok(format!("Flags set to {flags} for {device_handle}"))
@@ -105,7 +105,7 @@ impl ControlInterface {
                 "{bitstream_path_str} is not a valid path to a bitstream file."
             )));
         }
-        new_platform(device_handle)
+        new_platform(device_handle)?
             .fpga(device_handle)?
             .load_firmware(path)?;
         Ok(format!("{bitstream_path_str} loaded to {device_handle}"))
@@ -123,7 +123,7 @@ impl ControlInterface {
         );
         validate_device_handle(device_handle)?;
 
-        let platform = new_platform(device_handle);
+        let platform = new_platform(device_handle)?;
         let overlay_handler = platform.overlay_handler(overlay_handle)?;
         let overlay_fs_path = overlay_handler.overlay_fs_path()?;
         overlay_handler.apply_overlay(Path::new(overlay_source_path))?;
@@ -142,7 +142,7 @@ impl ControlInterface {
              {overlay_handle}"
         );
         validate_device_handle(device_handle)?;
-        let platform = new_platform(device_handle);
+        let platform = new_platform(device_handle)?;
         let overlay_handler = platform.overlay_handler(overlay_handle)?;
         let overlay_fs_path = overlay_handler.overlay_fs_path()?;
         overlay_handler.remove_overlay()?;

--- a/src/comm/dbus/interfaces.rs
+++ b/src/comm/dbus/interfaces.rs
@@ -10,10 +10,7 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config::system_config::{
-    config_fs_prefix, firmware_prefix, set_config_fs_prefix, set_firmware_prefix,
-    set_sys_fs_prefix, sys_fs_prefix,
-};
+use crate::config::system_config;
 use crate::error::FpgadError;
 use crate::platforms::platform::{Fpga, OverlayHandler, Platform, new_platform};
 use log::trace;
@@ -33,8 +30,11 @@ fn validate_device_handle(device_handle: &str) -> Result<(), FpgadError> {
                 fpga name must be compliant with sysfs rules."
         )));
     }
-    let sys_fs_prefix = sys_fs_prefix()?;
-    if !PathBuf::from(sys_fs_prefix).join(device_handle).exists() {
+    let fpga_managers_dir = system_config::fpga_managers_dir()?;
+    if !PathBuf::from(fpga_managers_dir)
+        .join(device_handle)
+        .exists()
+    {
         return Err(FpgadError::Argument(format!(
             "Device {device_handle} not found.",
         )));
@@ -154,33 +154,33 @@ impl ControlInterface {
 
 #[interface(name = "com.canonical.fpgad.configure")]
 impl ConfigureInterface {
-    async fn get_config_fs_prefix(&self) -> Result<String, fdo::Error> {
-        trace!("get_config_fs_prefix called");
-        Ok(config_fs_prefix()?)
+    async fn get_overlay_control_dir(&self) -> Result<String, fdo::Error> {
+        trace!("get_overlay_control_dir called");
+        Ok(system_config::overlay_control_dir()?)
     }
-    async fn get_firmware_prefix(&self) -> Result<String, fdo::Error> {
-        trace!("get_firmware_prefix called");
-        Ok(firmware_prefix()?)
-    }
-
-    async fn get_sys_fs_prefix(&self) -> Result<String, fdo::Error> {
-        trace!("get_sys_fs_prefix called");
-        Ok(sys_fs_prefix()?)
-    }
-    async fn set_config_fs_prefix(&self, prefix: &str) -> Result<String, fdo::Error> {
-        trace!("set_config_fs_prefix called with prefix: {prefix}");
-        set_config_fs_prefix(prefix.to_string())?;
-        Ok(format!("config_fs_prefix set to {prefix}"))
-    }
-    async fn set_firmware_prefix(&self, prefix: &str) -> Result<String, fdo::Error> {
-        trace!("set_firmware_prefix called with prefix: {prefix}");
-        set_firmware_prefix(prefix.to_string())?;
-        Ok(format!("firmware_prefix set to {prefix}"))
+    async fn get_firmware_source_dir(&self) -> Result<String, fdo::Error> {
+        trace!("get_firmware_source_dir called");
+        Ok(system_config::firmware_source_dir()?)
     }
 
-    async fn set_sys_fs_prefix(&self, prefix: &str) -> Result<String, fdo::Error> {
-        trace!("set_sys_fs_prefix called with prefix: {prefix}");
-        set_sys_fs_prefix(prefix.to_string())?;
-        Ok(format!("sys_fs_prefix set to {prefix}"))
+    async fn get_fpga_managers_dir(&self) -> Result<String, fdo::Error> {
+        trace!("get_fpga_managers_dir called");
+        Ok(system_config::fpga_managers_dir()?)
+    }
+    async fn set_overlay_control_dir(&self, new_path: &str) -> Result<String, fdo::Error> {
+        trace!("set_overlay_control_dir called with prefix: {new_path}");
+        system_config::set_overlay_control_dir(new_path.to_string())?;
+        Ok(format!("overlay_control_dir set to {new_path}"))
+    }
+    async fn set_firmware_source_dir(&self, new_path: &str) -> Result<String, fdo::Error> {
+        trace!("set_firmware_source_dir called with prefix: {new_path}");
+        system_config::set_firmware_source_dir(new_path.to_string())?;
+        Ok(format!("firmware_source_dir set to {new_path}"))
+    }
+
+    async fn set_fpga_managers_dir(&self, new_path: &str) -> Result<String, fdo::Error> {
+        trace!("set_fpga_managers_dir called with prefix: {new_path}");
+        system_config::set_fpga_managers_dir(new_path.to_string())?;
+        Ok(format!("fpga_managers_dir set to {new_path}"))
     }
 }

--- a/src/comm/dbus/interfaces.rs
+++ b/src/comm/dbus/interfaces.rs
@@ -10,7 +10,7 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config::system_config;
+use crate::config::{config_fs_prefix, firmware_prefix, sys_fs_prefix};
 use crate::error::FpgadError;
 use crate::platforms::platform::{Fpga, OverlayHandler, Platform, new_platform};
 use log::trace;
@@ -30,12 +30,10 @@ fn validate_device_handle(device_handle: &str) -> Result<(), FpgadError> {
                 fpga name must be compliant with sysfs rules."
         )));
     }
-    if !PathBuf::from(system_config().sys_fs_prefix())
-        .join(device_handle)
-        .exists()
-    {
+    let sys_fs_prefix = sys_fs_prefix()?;
+    if !PathBuf::from(sys_fs_prefix).join(device_handle).exists() {
         return Err(FpgadError::Argument(format!(
-            "Device {device_handle} not found."
+            "Device {device_handle} not found.",
         )));
     };
     Ok(())
@@ -167,13 +165,13 @@ impl ConfigureInterface {
     }
 
     async fn get_config_fs_prefix(&self) -> Result<String, fdo::Error> {
-        Ok(system_config().config_fs_prefix())
+        Ok(config_fs_prefix()?)
     }
     async fn get_firmware_prefix(&self) -> Result<String, fdo::Error> {
-        Ok(system_config().firmware_prefix())
+        Ok(firmware_prefix()?)
     }
 
     async fn get_sys_fs_prefix(&self) -> Result<String, fdo::Error> {
-        Ok(system_config().sys_fs_prefix())
+        Ok(sys_fs_prefix()?)
     }
 }

--- a/src/comm/dbus/interfaces.rs
+++ b/src/comm/dbus/interfaces.rs
@@ -10,7 +10,10 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config::{config_fs_prefix, firmware_prefix, sys_fs_prefix};
+use crate::config::system_config::{
+    config_fs_prefix, firmware_prefix, set_config_fs_prefix, set_firmware_prefix,
+    set_sys_fs_prefix, sys_fs_prefix,
+};
 use crate::error::FpgadError;
 use crate::platforms::platform::{Fpga, OverlayHandler, Platform, new_platform};
 use log::trace;
@@ -151,27 +154,33 @@ impl ControlInterface {
 
 #[interface(name = "com.canonical.fpgad.configure")]
 impl ConfigureInterface {
-    async fn set_firmware_prefix(&self, prefix: &str) -> Result<String, fdo::Error> {
-        trace!("set_firmware_prefix called with prefix: {prefix}");
-        Ok("Yeah, nah, assigning to static OnceCell isn't possible so this is WIP, sorry.".into())
-    }
-    async fn set_sys_fs_prefix(&self, prefix: &str) -> Result<String, fdo::Error> {
-        trace!("set_sys_fs_prefix called with prefix: {prefix}");
-        Ok("Yeah, nah, assigning to static OnceCell isn't possible so this is WIP, sorry.".into())
-    }
-    async fn set_config_fs_prefix(&self, prefix: &str) -> Result<String, fdo::Error> {
-        trace!("set_config_fs_prefix called with prefix: {prefix}");
-        Ok("Yeah, nah, assigning to static OnceCell isn't possible so this is WIP, sorry.".into())
-    }
-
     async fn get_config_fs_prefix(&self) -> Result<String, fdo::Error> {
+        trace!("get_config_fs_prefix called");
         Ok(config_fs_prefix()?)
     }
     async fn get_firmware_prefix(&self) -> Result<String, fdo::Error> {
+        trace!("get_firmware_prefix called");
         Ok(firmware_prefix()?)
     }
 
     async fn get_sys_fs_prefix(&self) -> Result<String, fdo::Error> {
+        trace!("get_sys_fs_prefix called");
         Ok(sys_fs_prefix()?)
+    }
+    async fn set_config_fs_prefix(&self, prefix: &str) -> Result<String, fdo::Error> {
+        trace!("set_config_fs_prefix called with prefix: {prefix}");
+        set_config_fs_prefix(prefix.to_string())?;
+        Ok(format!("config_fs_prefix set to {prefix}"))
+    }
+    async fn set_firmware_prefix(&self, prefix: &str) -> Result<String, fdo::Error> {
+        trace!("set_firmware_prefix called with prefix: {prefix}");
+        set_firmware_prefix(prefix.to_string())?;
+        Ok(format!("firmware_prefix set to {prefix}"))
+    }
+
+    async fn set_sys_fs_prefix(&self, prefix: &str) -> Result<String, fdo::Error> {
+        trace!("set_sys_fs_prefix called with prefix: {prefix}");
+        set_sys_fs_prefix(prefix.to_string())?;
+        Ok(format!("sys_fs_prefix set to {prefix}"))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,5 +56,5 @@ fn init_system_config() -> SystemConfig {
 }
 
 pub fn system_config() -> &'static SystemConfig {
-    CONFIG.get_or_init(|| init_system_config())
+    CONFIG.get_or_init(init_system_config)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,60 @@
-// TODO: this should be provided by the config
-pub static FW_PREFIX: &str = "/lib/firmware/";
-pub static SYSFS_PREFIX: &str = "/sys/class/fpga_manager/";
-pub static CONFIGFS_PREFIX: &str = "/sys/kernel/config/device-tree/overlays/";
+use std::sync::{Mutex, OnceLock};
+
+// TODO: this should be provided by the config file
+pub(crate) static CONFIG_FS_PREFIX: &str = "/sys/kernel/config/device-tree/overlays/";
+pub(crate) static FW_PREFIX: &str = "/lib/firmware/";
+pub(crate) static SYSFS_PREFIX: &str = "/sys/class/fpga_manager/";
+
+pub struct SystemConfig {
+    firmware_prefix: Mutex<String>,
+    sys_fs_prefix: Mutex<String>,
+    config_fs_prefix: Mutex<String>,
+}
+
+impl SystemConfig {
+    fn default() -> SystemConfig {
+        SystemConfig {
+            config_fs_prefix: Mutex::new(CONFIG_FS_PREFIX.to_string()),
+            firmware_prefix: Mutex::new(FW_PREFIX.to_string()),
+            sys_fs_prefix: Mutex::new(SYSFS_PREFIX.to_string()),
+        }
+    }
+}
+
+static CONFIG: OnceLock<SystemConfig> = OnceLock::new();
+
+impl SystemConfig {
+    #[allow(dead_code)]
+    pub fn set_config_fs_prefix(&mut self, prefix: String) {
+        *self.config_fs_prefix.lock().unwrap() = prefix;
+    }
+    #[allow(dead_code)]
+    pub fn set_firmware_prefix(&mut self, prefix: String) {
+        *self.firmware_prefix.lock().unwrap() = prefix;
+    }
+    #[allow(dead_code)]
+    pub fn set_sysfs_prefix(&mut self, prefix: String) {
+        *self.sys_fs_prefix.lock().unwrap() = prefix;
+    }
+
+    pub fn config_fs_prefix(&self) -> String {
+        self.config_fs_prefix.lock().unwrap().clone()
+    }
+
+    pub fn firmware_prefix(&self) -> String {
+        self.firmware_prefix.lock().unwrap().clone()
+    }
+
+    pub fn sys_fs_prefix(&self) -> String {
+        self.sys_fs_prefix.lock().unwrap().clone()
+    }
+}
+
+fn init_system_config() -> SystemConfig {
+    // TODO: read from file will happen here.
+    SystemConfig::default()
+}
+
+pub fn system_config() -> &'static SystemConfig {
+    CONFIG.get_or_init(|| init_system_config())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,14 +1,21 @@
-use std::sync::{Mutex, OnceLock};
+use crate::error::FpgadError;
+use crate::system_io::fs_read;
+use log::{trace, warn};
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
-// TODO: this should be provided by the config file
-pub(crate) static CONFIG_FS_PREFIX: &str = "/sys/kernel/config/device-tree/overlays/";
-pub(crate) static FW_PREFIX: &str = "/lib/firmware/";
-pub(crate) static SYSFS_PREFIX: &str = "/sys/class/fpga_manager/";
+// These are hardcoded backups to prevent crashing and lockups when accessing the config file
+// or Mutex values
+pub static CONFIG_FS_PREFIX: &str = "/sys/kernel/config/device-tree/overlays/";
+pub static FW_PREFIX: &str = "/lib/firmware/";
+pub static SYSFS_PREFIX: &str = "/sys/class/fpga_manager/";
 
+#[derive(Debug)]
 pub struct SystemConfig {
+    config_fs_prefix: Mutex<String>,
     firmware_prefix: Mutex<String>,
     sys_fs_prefix: Mutex<String>,
-    config_fs_prefix: Mutex<String>,
 }
 
 impl SystemConfig {
@@ -21,40 +28,181 @@ impl SystemConfig {
     }
 }
 
-static CONFIG: OnceLock<SystemConfig> = OnceLock::new();
+static CONFIG: OnceLock<Mutex<SystemConfig>> = OnceLock::new();
 
 impl SystemConfig {
-    #[allow(dead_code)]
-    pub fn set_config_fs_prefix(&mut self, prefix: String) {
-        *self.config_fs_prefix.lock().unwrap() = prefix;
-    }
-    #[allow(dead_code)]
-    pub fn set_firmware_prefix(&mut self, prefix: String) {
-        *self.firmware_prefix.lock().unwrap() = prefix;
-    }
-    #[allow(dead_code)]
-    pub fn set_sysfs_prefix(&mut self, prefix: String) {
-        *self.sys_fs_prefix.lock().unwrap() = prefix;
-    }
-
-    pub fn config_fs_prefix(&self) -> String {
-        self.config_fs_prefix.lock().unwrap().clone()
+    fn config_fs_prefix(&self) -> Result<String, FpgadError> {
+        let guard = match self.config_fs_prefix.try_lock() {
+            Ok(guard) => guard,
+            Err(e) => {
+                return Err(FpgadError::Internal(format!(
+                    "Failed when locking config_fs_prefix for read access: {e}"
+                )));
+            }
+        };
+        Ok(guard.clone())
     }
 
-    pub fn firmware_prefix(&self) -> String {
-        self.firmware_prefix.lock().unwrap().clone()
+    fn firmware_prefix(&self) -> Result<String, FpgadError> {
+        let guard = match self.firmware_prefix.try_lock() {
+            Ok(guard) => guard,
+            Err(e) => {
+                return Err(FpgadError::Internal(format!(
+                    "Failed when locking firmware_prefix for read access: {e}"
+                )));
+            }
+        };
+
+        Ok(guard.clone())
     }
 
-    pub fn sys_fs_prefix(&self) -> String {
-        self.sys_fs_prefix.lock().unwrap().clone()
+    fn sys_fs_prefix(&self) -> Result<String, FpgadError> {
+        let guard = match self.sys_fs_prefix.try_lock() {
+            Ok(guard) => guard,
+            Err(e) => {
+                return Err(FpgadError::Internal(format!(
+                    "Failed when locking sys_fs_prefix for read access: {e}"
+                )));
+            }
+        };
+        Ok(guard.clone())
+    }
+}
+/// This is the top level struct which holds all sections
+#[derive(Debug, Deserialize)]
+struct TomlConfig {
+    defaults: Option<DefaultsToml>,
+}
+
+/// This is the "defaults" struct
+#[derive(Debug, Deserialize)]
+struct DefaultsToml {
+    config_fs_prefix: Option<String>,
+    firmware_prefix: Option<String>,
+    sys_fs_prefix: Option<String>,
+}
+
+impl From<DefaultsToml> for SystemConfig {
+    fn from(value: DefaultsToml) -> Self {
+        trace!("User provided config: {value:?}");
+        SystemConfig {
+            config_fs_prefix: Mutex::new(value.config_fs_prefix.unwrap_or_else(|| {
+                trace!("No config_fs_prefix provided. Using hardcoded value.");
+                CONFIG_FS_PREFIX.to_string()
+            })),
+            firmware_prefix: Mutex::new(value.firmware_prefix.unwrap_or_else(|| {
+                trace!("No firmware_prefix provided. Using hardcoded value.");
+                FW_PREFIX.to_string()
+            })),
+            sys_fs_prefix: Mutex::new(value.sys_fs_prefix.unwrap_or_else(|| {
+                trace!("No sys_fs_prefix provided. Using hardcoded value.");
+                SYSFS_PREFIX.to_string()
+            })),
+        }
     }
 }
 
-fn init_system_config() -> SystemConfig {
-    // TODO: read from file will happen here.
-    SystemConfig::default()
+fn config_from_file() -> Result<SystemConfig, FpgadError> {
+    let config_path = PathBuf::from("/etc/fpgad/config.toml");
+    if !config_path.is_file() {
+        return Err(FpgadError::Internal(format!(
+            "Config file not found in {config_path:?}. \
+        Using hardcoded defaults"
+        )));
+    }
+    let toml_string = fs_read(&config_path)?;
+
+    let config: TomlConfig = match toml::from_str(&toml_string) {
+        Ok(config) => config,
+        Err(e) => {
+            return Err(FpgadError::TomlDe {
+                file: config_path,
+                e,
+            });
+        }
+    };
+    match config.defaults {
+        Some(defaults_toml) => Ok(defaults_toml.into()),
+        None => Err(FpgadError::Internal(
+            "config file did not contain a `[defaults]` section.".to_string(),
+        )),
+    }
 }
 
-pub fn system_config() -> &'static SystemConfig {
+fn init_system_config() -> Mutex<SystemConfig> {
+    match config_from_file() {
+        Ok(config) => {
+            trace!("Successfully loaded config: {config:?}");
+            Mutex::new(config)
+        }
+        Err(e) => {
+            warn!("Using hardcoded paths because failed to load config: {e}");
+            Mutex::new(SystemConfig::default())
+        }
+    }
+}
+pub fn system_config() -> &'static Mutex<SystemConfig> {
     CONFIG.get_or_init(init_system_config)
+}
+
+pub fn system_config_guard() -> Result<MutexGuard<'static, SystemConfig>, FpgadError> {
+    let guard = match system_config().try_lock() {
+        Ok(guard) => guard,
+        Err(e) => {
+            return Err(FpgadError::Internal(format!(
+                "Failed when locking config for read access: {e}"
+            )));
+        }
+    };
+    Ok(guard)
+}
+
+pub fn config_fs_prefix() -> Result<String, FpgadError> {
+    let guard = system_config_guard()?;
+    guard.config_fs_prefix()
+}
+
+pub fn firmware_prefix() -> Result<String, FpgadError> {
+    let guard = system_config_guard()?;
+    guard.firmware_prefix()
+}
+
+pub fn sys_fs_prefix() -> Result<String, FpgadError> {
+    let guard = system_config_guard()?;
+    guard.sys_fs_prefix()
+}
+
+pub fn set_config_fs_prefix(prefix: String) -> Result<(), FpgadError> {
+    let config = system_config_guard()?;
+
+    *config
+        .config_fs_prefix
+        .lock()
+        .map_err(|e| FpgadError::Internal(format!("Failed to lock config_fs_prefix: {e}")))? =
+        prefix;
+
+    Ok(())
+}
+
+pub fn set_firmware_prefix(prefix: String) -> Result<(), FpgadError> {
+    let config = system_config_guard()?;
+
+    *config
+        .firmware_prefix
+        .lock()
+        .map_err(|e| FpgadError::Internal(format!("Failed to lock firmware_prefix: {e}")))? =
+        prefix;
+
+    Ok(())
+}
+
+pub fn set_sys_fs_prefix(prefix: String) -> Result<(), FpgadError> {
+    let config = system_config_guard()?;
+
+    *config
+        .sys_fs_prefix
+        .lock()
+        .map_err(|e| FpgadError::Internal(format!("Failed to lock sys_fs_prefix: {e}")))? = prefix;
+
+    Ok(())
 }

--- a/src/config/config_files.rs
+++ b/src/config/config_files.rs
@@ -1,4 +1,4 @@
-use crate::config::system_config::{CONFIG_FS_PREFIX, FW_PREFIX, SYSFS_PREFIX, SystemConfig};
+use crate::config::system_config;
 use crate::error::FpgadError;
 use crate::system_io::fs_read;
 use log::trace;
@@ -15,26 +15,26 @@ pub(crate) struct TomlConfig {
 /// This is the "defaults" section struct
 #[derive(Debug, Deserialize)]
 pub(crate) struct SystemPaths {
-    config_fs_prefix: Option<String>,
-    firmware_prefix: Option<String>,
-    sys_fs_prefix: Option<String>,
+    overlay_control_dir: Option<String>,
+    firmware_source_dir: Option<String>,
+    fpga_managers_dir: Option<String>,
 }
 
-impl From<SystemPaths> for SystemConfig {
+impl From<SystemPaths> for system_config::SystemConfig {
     fn from(value: SystemPaths) -> Self {
         trace!("Creating Config (with Mutex) from {value:?}");
-        SystemConfig {
-            config_fs_prefix: Mutex::new(value.config_fs_prefix.unwrap_or_else(|| {
-                trace!("No config_fs_prefix provided. Using hardcoded value.");
-                CONFIG_FS_PREFIX.to_string()
+        system_config::SystemConfig {
+            overlay_control_dir: Mutex::new(value.overlay_control_dir.unwrap_or_else(|| {
+                trace!("No overlay_control_dir provided. Using hardcoded value.");
+                system_config::OVERLAY_CONTROL_DIR.to_string()
             })),
-            firmware_prefix: Mutex::new(value.firmware_prefix.unwrap_or_else(|| {
-                trace!("No firmware_prefix provided. Using hardcoded value.");
-                FW_PREFIX.to_string()
+            firmware_source_dir: Mutex::new(value.firmware_source_dir.unwrap_or_else(|| {
+                trace!("No firmware_source_dir provided. Using hardcoded value.");
+                system_config::FIRMWARE_SOURCE_DIR.to_string()
             })),
-            sys_fs_prefix: Mutex::new(value.sys_fs_prefix.unwrap_or_else(|| {
-                trace!("No sys_fs_prefix provided. Using hardcoded value.");
-                SYSFS_PREFIX.to_string()
+            fpga_managers_dir: Mutex::new(value.fpga_managers_dir.unwrap_or_else(|| {
+                trace!("No fpga_managers_dir provided. Using hardcoded value.");
+                system_config::FPGA_MANAGERS_DIR.to_string()
             })),
         }
     }
@@ -43,16 +43,16 @@ impl From<SystemPaths> for SystemConfig {
 impl SystemPaths {
     pub(crate) fn default() -> SystemPaths {
         SystemPaths {
-            config_fs_prefix: None,
-            firmware_prefix: None,
-            sys_fs_prefix: None,
+            overlay_control_dir: None,
+            firmware_source_dir: None,
+            fpga_managers_dir: None,
         }
     }
     pub(crate) fn merge(self, fallback: SystemPaths) -> SystemPaths {
         SystemPaths {
-            config_fs_prefix: self.config_fs_prefix.or(fallback.config_fs_prefix),
-            firmware_prefix: self.firmware_prefix.or(fallback.firmware_prefix),
-            sys_fs_prefix: self.sys_fs_prefix.or(fallback.sys_fs_prefix),
+            overlay_control_dir: self.overlay_control_dir.or(fallback.overlay_control_dir),
+            firmware_source_dir: self.firmware_source_dir.or(fallback.firmware_source_dir),
+            fpga_managers_dir: self.fpga_managers_dir.or(fallback.fpga_managers_dir),
         }
     }
 }

--- a/src/config/config_files.rs
+++ b/src/config/config_files.rs
@@ -1,0 +1,85 @@
+use crate::config::system_config::{CONFIG_FS_PREFIX, FW_PREFIX, SYSFS_PREFIX, SystemConfig};
+use crate::error::FpgadError;
+use crate::system_io::fs_read;
+use log::trace;
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// This is the top level struct which holds all sections
+#[derive(Debug, Deserialize)]
+pub(crate) struct TomlConfig {
+    defaults: Option<SystemPaths>,
+}
+
+/// This is the "defaults" section struct
+#[derive(Debug, Deserialize)]
+pub(crate) struct SystemPaths {
+    config_fs_prefix: Option<String>,
+    firmware_prefix: Option<String>,
+    sys_fs_prefix: Option<String>,
+}
+
+impl From<SystemPaths> for SystemConfig {
+    fn from(value: SystemPaths) -> Self {
+        trace!("Creating Config (with Mutex) from {value:?}");
+        SystemConfig {
+            config_fs_prefix: Mutex::new(value.config_fs_prefix.unwrap_or_else(|| {
+                trace!("No config_fs_prefix provided. Using hardcoded value.");
+                CONFIG_FS_PREFIX.to_string()
+            })),
+            firmware_prefix: Mutex::new(value.firmware_prefix.unwrap_or_else(|| {
+                trace!("No firmware_prefix provided. Using hardcoded value.");
+                FW_PREFIX.to_string()
+            })),
+            sys_fs_prefix: Mutex::new(value.sys_fs_prefix.unwrap_or_else(|| {
+                trace!("No sys_fs_prefix provided. Using hardcoded value.");
+                SYSFS_PREFIX.to_string()
+            })),
+        }
+    }
+}
+
+impl SystemPaths {
+    pub(crate) fn default() -> SystemPaths {
+        SystemPaths {
+            config_fs_prefix: None,
+            firmware_prefix: None,
+            sys_fs_prefix: None,
+        }
+    }
+    pub(crate) fn merge(self, fallback: SystemPaths) -> SystemPaths {
+        SystemPaths {
+            config_fs_prefix: self.config_fs_prefix.or(fallback.config_fs_prefix),
+            firmware_prefix: self.firmware_prefix.or(fallback.firmware_prefix),
+            sys_fs_prefix: self.sys_fs_prefix.or(fallback.sys_fs_prefix),
+        }
+    }
+}
+
+pub(crate) fn system_paths_config_from_file(
+    file_path: &PathBuf,
+) -> Result<SystemPaths, FpgadError> {
+    if !file_path.is_file() {
+        return Err(FpgadError::Internal(format!(
+            "Config file not found in {file_path:?}"
+        )));
+    }
+    let toml_string = fs_read(file_path)?;
+
+    let config: TomlConfig = match toml::from_str(&toml_string) {
+        Ok(config) => config,
+        Err(e) => {
+            return Err(FpgadError::TomlDe {
+                toml_string: toml_string.clone(),
+                e,
+            });
+        }
+    };
+    match config.defaults {
+        Some(defaults_toml) => Ok(defaults_toml),
+        None => Err(FpgadError::Internal(
+            "config file did not contain a `[defaults]` section.".to_string(),
+        )),
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,14 @@
+// This file is part of fpgad, an application to manage FPGA subsystem together with device-tree and kernel modules.
+//
+// Copyright 2025 Canonical Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// fpgad is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 3, as published by the Free Software Foundation.
+//
+// fpgad is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranties of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
+
+pub(crate) mod config_files;
+pub mod system_config;

--- a/src/config/system_config.rs
+++ b/src/config/system_config.rs
@@ -7,38 +7,38 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 
 // These are hardcoded backups to prevent crashing and lockups when accessing the config file
 // or Mutex values
-pub static CONFIG_FS_PREFIX: &str = "/sys/kernel/config/device-tree/overlays/";
-pub static FW_PREFIX: &str = "/lib/firmware/";
-pub static SYSFS_PREFIX: &str = "/sys/class/fpga_manager/";
+pub static OVERLAY_CONTROL_DIR: &str = "/sys/kernel/config/device-tree/overlays/";
+pub static FIRMWARE_SOURCE_DIR: &str = "/lib/firmware/";
+pub static FPGA_MANAGERS_DIR: &str = "/sys/class/fpga_manager/";
 
 #[derive(Debug)]
 pub struct SystemConfig {
-    pub(crate) config_fs_prefix: Mutex<String>,
-    pub(crate) firmware_prefix: Mutex<String>,
-    pub(crate) sys_fs_prefix: Mutex<String>,
+    pub(crate) overlay_control_dir: Mutex<String>,
+    pub(crate) firmware_source_dir: Mutex<String>,
+    pub(crate) fpga_managers_dir: Mutex<String>,
 }
 
 static CONFIG: OnceLock<Mutex<SystemConfig>> = OnceLock::new();
 
 impl SystemConfig {
-    fn config_fs_prefix(&self) -> Result<String, FpgadError> {
-        let guard = match self.config_fs_prefix.try_lock() {
+    fn overlay_control_dir(&self) -> Result<String, FpgadError> {
+        let guard = match self.overlay_control_dir.try_lock() {
             Ok(guard) => guard,
             Err(e) => {
                 return Err(FpgadError::Internal(format!(
-                    "Failed when locking config_fs_prefix for read access: {e}"
+                    "Failed when locking overlay_control_dir for read access: {e}"
                 )));
             }
         };
         Ok(guard.clone())
     }
 
-    fn firmware_prefix(&self) -> Result<String, FpgadError> {
-        let guard = match self.firmware_prefix.try_lock() {
+    fn firmware_source_dir(&self) -> Result<String, FpgadError> {
+        let guard = match self.firmware_source_dir.try_lock() {
             Ok(guard) => guard,
             Err(e) => {
                 return Err(FpgadError::Internal(format!(
-                    "Failed when locking firmware_prefix for read access: {e}"
+                    "Failed when locking firmware_source_dir for read access: {e}"
                 )));
             }
         };
@@ -46,12 +46,12 @@ impl SystemConfig {
         Ok(guard.clone())
     }
 
-    fn sys_fs_prefix(&self) -> Result<String, FpgadError> {
-        let guard = match self.sys_fs_prefix.try_lock() {
+    fn fpga_managers_dir(&self) -> Result<String, FpgadError> {
+        let guard = match self.fpga_managers_dir.try_lock() {
             Ok(guard) => guard,
             Err(e) => {
                 return Err(FpgadError::Internal(format!(
-                    "Failed when locking sys_fs_prefix for read access: {e}"
+                    "Failed when locking fpga_managers_dir for read access: {e}"
                 )));
             }
         };
@@ -94,52 +94,50 @@ pub fn system_config_guard() -> Result<MutexGuard<'static, SystemConfig>, FpgadE
     Ok(guard)
 }
 
-pub fn config_fs_prefix() -> Result<String, FpgadError> {
-    let guard = system_config_guard()?;
-    guard.config_fs_prefix()
+pub fn overlay_control_dir() -> Result<String, FpgadError> {
+    system_config_guard()?.overlay_control_dir()
 }
 
-pub fn firmware_prefix() -> Result<String, FpgadError> {
-    let guard = system_config_guard()?;
-    guard.firmware_prefix()
+pub fn firmware_source_dir() -> Result<String, FpgadError> {
+    system_config_guard()?.firmware_source_dir()
 }
 
-pub fn sys_fs_prefix() -> Result<String, FpgadError> {
-    let guard = system_config_guard()?;
-    guard.sys_fs_prefix()
+pub fn fpga_managers_dir() -> Result<String, FpgadError> {
+    system_config_guard()?.fpga_managers_dir()
 }
 
-pub fn set_config_fs_prefix(prefix: String) -> Result<(), FpgadError> {
+pub fn set_overlay_control_dir(prefix: String) -> Result<(), FpgadError> {
     let config = system_config_guard()?;
 
     *config
-        .config_fs_prefix
+        .overlay_control_dir
         .lock()
-        .map_err(|e| FpgadError::Internal(format!("Failed to lock config_fs_prefix: {e}")))? =
+        .map_err(|e| FpgadError::Internal(format!("Failed to lock overlay_control_dir: {e}")))? =
         prefix;
 
     Ok(())
 }
 
-pub fn set_firmware_prefix(prefix: String) -> Result<(), FpgadError> {
+pub fn set_firmware_source_dir(prefix: String) -> Result<(), FpgadError> {
     let config = system_config_guard()?;
 
     *config
-        .firmware_prefix
+        .firmware_source_dir
         .lock()
-        .map_err(|e| FpgadError::Internal(format!("Failed to lock firmware_prefix: {e}")))? =
+        .map_err(|e| FpgadError::Internal(format!("Failed to lock firmware_source_dir: {e}")))? =
         prefix;
 
     Ok(())
 }
 
-pub fn set_sys_fs_prefix(prefix: String) -> Result<(), FpgadError> {
+pub fn set_fpga_managers_dir(prefix: String) -> Result<(), FpgadError> {
     let config = system_config_guard()?;
 
     *config
-        .sys_fs_prefix
+        .fpga_managers_dir
         .lock()
-        .map_err(|e| FpgadError::Internal(format!("Failed to lock sys_fs_prefix: {e}")))? = prefix;
+        .map_err(|e| FpgadError::Internal(format!("Failed to lock fpga_managers_dir: {e}")))? =
+        prefix;
 
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,8 +38,11 @@ pub enum FpgadError {
     IODelete { file: PathBuf, e: std::io::Error },
     #[error("FpgadError::Internal: An Internal error occurred: {0}")]
     Internal(String),
-    #[error("FpgadError::Toml: Deserializing {file:?} failed: {e}")]
-    TomlDe { file: PathBuf, e: toml::de::Error },
+    #[error("FpgadError::Toml: Deserializing {toml_string} failed: {e}")]
+    TomlDe {
+        toml_string: String,
+        e: toml::de::Error,
+    },
 }
 
 impl From<FpgadError> for fdo::Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,8 @@ pub enum FpgadError {
     IODelete { file: PathBuf, e: std::io::Error },
     #[error("FpgadError::Internal: An Internal error occurred: {0}")]
     Internal(String),
+    #[error("FpgadError::Toml: Deserializing {file:?} failed: {e}")]
+    TomlDe { file: PathBuf, e: toml::de::Error },
 }
 
 impl From<FpgadError> for fdo::Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,7 +42,7 @@ pub enum FpgadError {
 
 impl From<FpgadError> for fdo::Error {
     fn from(err: FpgadError) -> Self {
-        error!("{}", err);
+        error!("{err}");
         match err {
             FpgadError::Argument(..) => fdo::Error::InvalidArgs(err.to_string()),
             FpgadError::IORead { .. } => fdo::Error::IOError(err.to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod config;
 mod platforms;
 mod system_io;
 
-use crate::comm::dbus::interfaces::{ControlInterface, StatusInterface};
+use crate::comm::dbus::interfaces::{ConfigureInterface, ControlInterface, StatusInterface};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -32,11 +32,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // based on its name in /sys/class/fpga_manager/{device}/name
     let status_interface = StatusInterface {};
     let control_interface = ControlInterface {};
+    let configure_interface = ConfigureInterface {};
 
     let _conn = connection::Builder::system()?
         .name("com.canonical.fpgad")?
         .serve_at("/com/canonical/fpgad/status", status_interface)?
         .serve_at("/com/canonical/fpgad/control", control_interface)?
+        .serve_at("/com/canonical/fpgad/configure", configure_interface)?
         .build()
         .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,13 @@ mod platforms;
 mod system_io;
 
 use crate::comm::dbus::interfaces::{ConfigureInterface, ControlInterface, StatusInterface};
+use crate::config::system_config::system_config;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
-
+    // call to initialise
+    let _ = system_config();
     // Upon load, the daemon will search each fpga device and determine what platform it is
     // based on its name in /sys/class/fpga_manager/{device}/name
     let status_interface = StatusInterface {};

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -10,7 +10,7 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config::system_config::{SYSFS_PREFIX, sys_fs_prefix};
+use crate::config::system_config;
 use crate::error::FpgadError;
 use crate::platforms::universal::UniversalPlatform;
 use crate::system_io::fs_read;
@@ -32,7 +32,7 @@ const PLATFORM_SUBSTRINGS: &[(&str, PlatformType)] = &[
 /// Scans /sys/class/fpga_manager/ for all present device nodes and returns a Vec of their handles
 #[allow(dead_code)]
 pub async fn list_fpga_managers() -> Vec<String> {
-    let prefix = sys_fs_prefix().unwrap_or_else(|_| SYSFS_PREFIX.to_string());
+    let prefix = system_config::fpga_managers_dir().unwrap_or_else(|_| system_config::FPGA_MANAGERS_DIR.to_string());
     std::fs::read_dir(prefix)
         .map(|iter| {
             iter.filter_map(Result::ok)
@@ -97,7 +97,7 @@ pub trait OverlayHandler {
 }
 
 fn discover_platform_type(device_handle: &str) -> PlatformType {
-    let prefix = sys_fs_prefix().unwrap_or_else(|_| SYSFS_PREFIX.to_string());
+    let prefix = system_config::fpga_managers_dir().unwrap_or_else(|_| system_config::FPGA_MANAGERS_DIR.to_string());
     let compat_string = match fs_read(
         &Path::new(&prefix)
             .join(device_handle)

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -10,7 +10,7 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config::{SYSFS_PREFIX, sys_fs_prefix};
+use crate::config::system_config::{SYSFS_PREFIX, sys_fs_prefix};
 use crate::error::FpgadError;
 use crate::platforms::universal::UniversalPlatform;
 use crate::system_io::fs_read;

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -103,15 +103,14 @@ fn discover_platform_type(device_handle: &str) -> PlatformType {
     ) {
         Err(e) => {
             error!(
-                "Failed to read platform from {:?}: {}\n\
-                Universal will be used as platform type.",
-                device_handle, e
+                "Failed to read platform from {device_handle:?}: {e}\n\
+                Universal will be used as platform type."
             );
             return PlatformType::Universal;
         }
         Ok(s) => s,
     };
-    trace!("Found compatibility string: '{}'", compat_string);
+    trace!("Found compatibility string: '{compat_string}'");
 
     for (substr, platform) in PLATFORM_SUBSTRINGS {
         if compat_string.contains(substr) {

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -10,7 +10,7 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config;
+use crate::config::system_config;
 use crate::error::FpgadError;
 use crate::platforms::universal::UniversalPlatform;
 use crate::system_io::fs_read;
@@ -31,8 +31,8 @@ const PLATFORM_SUBSTRINGS: &[(&str, PlatformType)] = &[
 
 /// Scans /sys/class/fpga_manager/ for all present device nodes and returns a Vec of their handles
 #[allow(dead_code)]
-pub fn list_fpga_managers() -> Vec<String> {
-    std::fs::read_dir(config::SYSFS_PREFIX)
+pub async fn list_fpga_managers() -> Vec<String> {
+    std::fs::read_dir(system_config().sys_fs_prefix())
         .map(|iter| {
             iter.filter_map(Result::ok)
                 .map(|entry| entry.file_name().to_string_lossy().into_owned())
@@ -97,7 +97,7 @@ pub trait OverlayHandler {
 
 fn discover_platform_type(device_handle: &str) -> PlatformType {
     let compat_string = match fs_read(
-        &Path::new(config::SYSFS_PREFIX)
+        &Path::new(&system_config().sys_fs_prefix())
             .join(device_handle)
             .join("of_node/compatible"),
     ) {

--- a/src/platforms/universal.rs
+++ b/src/platforms/universal.rs
@@ -15,13 +15,14 @@ use crate::platforms::platform::{Fpga, OverlayHandler, Platform};
 use crate::platforms::universal_components::universal_fpga::UniversalFPGA;
 use crate::platforms::universal_components::universal_overlay_handler::UniversalOverlayHandler;
 use log::trace;
-use std::cell::OnceCell;
+// use tokio::sync::OnceCell;
+use std::sync::{OnceLock};
 
 #[derive(Debug)]
 pub struct UniversalPlatform {
     platform_type: &'static str,
-    fpga: OnceCell<UniversalFPGA>,
-    overlay_handler: OnceCell<UniversalOverlayHandler>,
+    fpga: OnceLock<UniversalFPGA>,
+    overlay_handler: OnceLock<UniversalOverlayHandler>,
 }
 
 impl UniversalPlatform {
@@ -30,8 +31,8 @@ impl UniversalPlatform {
         trace!("creating new universal_platform");
         UniversalPlatform {
             platform_type: "Universal",
-            fpga: OnceCell::new(),
-            overlay_handler: OnceCell::new(),
+            fpga: OnceLock::new(),
+            overlay_handler: OnceLock::new(),
         }
     }
 }

--- a/src/platforms/universal.rs
+++ b/src/platforms/universal.rs
@@ -16,7 +16,7 @@ use crate::platforms::universal_components::universal_fpga::UniversalFPGA;
 use crate::platforms::universal_components::universal_overlay_handler::UniversalOverlayHandler;
 use log::trace;
 // use tokio::sync::OnceCell;
-use std::sync::{OnceLock};
+use std::sync::OnceLock;
 
 #[derive(Debug)]
 pub struct UniversalPlatform {
@@ -62,8 +62,7 @@ impl Platform for UniversalPlatform {
 
         if !parent_path.exists() {
             return Err(FpgadError::Argument(format!(
-                "The overlayfs path {:?} doesn't seem to exist.",
-                parent_path
+                "The overlayfs path {parent_path:?} doesn't seem to exist."
             )));
         }
         Ok(handler)

--- a/src/platforms/universal.rs
+++ b/src/platforms/universal.rs
@@ -50,9 +50,14 @@ impl Platform for UniversalPlatform {
 
     /// Gets the `overlay_handler` associated with this device.
     fn overlay_handler(&self, overlay_handle: &str) -> Result<&impl OverlayHandler, FpgadError> {
+        // TODO: replace the return type of UniversalOverlayHandler to Result and use
+        // get_or_try_init instead here when stable:
+        // https://github.com/rust-lang/rust/issues/121641
         let handler = self
             .overlay_handler
             .get_or_init(|| UniversalOverlayHandler::new(overlay_handle));
+
+        // NOTE: This will fail if the constructor fails.
         let parent_path = handler.overlay_fs_path()?.parent().ok_or_else(|| {
             FpgadError::Argument(format!(
                 "The path {:?} has no parent directory.",

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -10,7 +10,7 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config::system_config;
+use crate::config::{firmware_prefix, sys_fs_prefix};
 use crate::error::FpgadError;
 use crate::platforms::platform::Fpga;
 use crate::system_io::{fs_read, fs_write};
@@ -61,7 +61,7 @@ impl Fpga for UniversalFPGA {
     ///
     /// returns: Result<String, FpgadError>
     fn state(&self) -> Result<String, FpgadError> {
-        let state_path = Path::new(&system_config().sys_fs_prefix())
+        let state_path = Path::new(&sys_fs_prefix()?)
             .join(self.device_handle.clone())
             .join("state");
         trace!("reading {state_path:?}");
@@ -71,7 +71,7 @@ impl Fpga for UniversalFPGA {
     /// Gets the flags from the hex string stored in the sysfs flags file
     /// e.g. sys/class/fpga_manager/fpga0/flags
     fn flags(&self) -> Result<isize, FpgadError> {
-        let flag_path = Path::new(&system_config().sys_fs_prefix())
+        let flag_path = Path::new(&sys_fs_prefix()?)
             .join(self.device_handle.clone())
             .join("flags");
         let contents = fs_read(&flag_path)?;
@@ -83,7 +83,7 @@ impl Fpga for UniversalFPGA {
     /// Sets the flags in the sysfs flags file (e.g. sys/class/fpga_manager/fpga0/flags)
     /// and verifies the write command stuck by reading it back.
     fn set_flags(&self, flags: isize) -> Result<(), FpgadError> {
-        let flag_path = Path::new(&system_config().sys_fs_prefix())
+        let flag_path = Path::new(&sys_fs_prefix()?)
             .join(self.device_handle.clone())
             .join("flags");
         trace!("Writing '{flags}' to '{flag_path:?}");
@@ -109,7 +109,6 @@ impl Fpga for UniversalFPGA {
             },
             Err(e) => return Err(e),
         };
-
         match self.flags() {
             Ok(returned_flags) if returned_flags == flags => Ok(()),
             Ok(returned_flags) => Err(FpgadError::Flag(format!(
@@ -126,15 +125,12 @@ impl Fpga for UniversalFPGA {
     /// This can be used to manually load a firmware if the overlay does not trigger the load.
     /// Note: always load firmware before overlay.
     fn load_firmware(&self, bitstream_path: &Path) -> Result<(), FpgadError> {
-        let stripped_path = bitstream_path
-            .strip_prefix(system_config().firmware_prefix())
-            .map_err(|_| {
-                FpgadError::Argument(format!(
-                    "Bitstream path {:?} is not under the configured firmware directory '{}'",
-                    bitstream_path,
-                    system_config().firmware_prefix()
-                ))
-            })?;
+        let prefix = firmware_prefix()?;
+        let stripped_path = bitstream_path.strip_prefix(&prefix).map_err(|_| {
+            FpgadError::Argument(format!(
+                "Bitstream path {bitstream_path:?} is not under the configured firmware directory '{prefix}'"
+            ))
+        })?;
 
         let relative_path = stripped_path.to_str().ok_or_else(|| {
             FpgadError::Argument(format!(
@@ -142,7 +138,7 @@ impl Fpga for UniversalFPGA {
             ))
         })?;
 
-        let control_path = Path::new(&system_config().sys_fs_prefix())
+        let control_path = Path::new(&sys_fs_prefix()?)
             .join(self.device_handle())
             .join("firmware");
         fs_write(&control_path, false, relative_path)?;

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -138,8 +138,7 @@ impl Fpga for UniversalFPGA {
 
         let relative_path = stripped_path.to_str().ok_or_else(|| {
             FpgadError::Argument(format!(
-                "Stripped bitstream path {:?} is not valid UTF-8",
-                stripped_path
+                "Stripped bitstream path {stripped_path:?} is not valid UTF-8"
             ))
         })?;
 

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -10,7 +10,7 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config::system_config::{firmware_prefix, sys_fs_prefix};
+use crate::config::system_config;
 use crate::error::FpgadError;
 use crate::platforms::platform::Fpga;
 use crate::system_io::{fs_read, fs_write};
@@ -61,7 +61,7 @@ impl Fpga for UniversalFPGA {
     ///
     /// returns: Result<String, FpgadError>
     fn state(&self) -> Result<String, FpgadError> {
-        let state_path = Path::new(&sys_fs_prefix()?)
+        let state_path = Path::new(&system_config::fpga_managers_dir()?)
             .join(self.device_handle.clone())
             .join("state");
         trace!("reading {state_path:?}");
@@ -71,7 +71,7 @@ impl Fpga for UniversalFPGA {
     /// Gets the flags from the hex string stored in the sysfs flags file
     /// e.g. sys/class/fpga_manager/fpga0/flags
     fn flags(&self) -> Result<isize, FpgadError> {
-        let flag_path = Path::new(&sys_fs_prefix()?)
+        let flag_path = Path::new(&system_config::fpga_managers_dir()?)
             .join(self.device_handle.clone())
             .join("flags");
         let contents = fs_read(&flag_path)?;
@@ -83,7 +83,7 @@ impl Fpga for UniversalFPGA {
     /// Sets the flags in the sysfs flags file (e.g. sys/class/fpga_manager/fpga0/flags)
     /// and verifies the write command stuck by reading it back.
     fn set_flags(&self, flags: isize) -> Result<(), FpgadError> {
-        let flag_path = Path::new(&sys_fs_prefix()?)
+        let flag_path = Path::new(&system_config::fpga_managers_dir()?)
             .join(self.device_handle.clone())
             .join("flags");
         trace!("Writing '{flags}' to '{flag_path:?}");
@@ -125,7 +125,7 @@ impl Fpga for UniversalFPGA {
     /// This can be used to manually load a firmware if the overlay does not trigger the load.
     /// Note: always load firmware before overlay.
     fn load_firmware(&self, bitstream_path: &Path) -> Result<(), FpgadError> {
-        let prefix = firmware_prefix()?;
+        let prefix = system_config::firmware_source_dir()?;
         let stripped_path = bitstream_path.strip_prefix(&prefix).map_err(|_| {
             FpgadError::Argument(format!(
                 "Bitstream path {bitstream_path:?} is not under the configured firmware directory '{prefix}'"
@@ -138,7 +138,7 @@ impl Fpga for UniversalFPGA {
             ))
         })?;
 
-        let control_path = Path::new(&sys_fs_prefix()?)
+        let control_path = Path::new(&system_config::fpga_managers_dir()?)
             .join(self.device_handle())
             .join("firmware");
         fs_write(&control_path, false, relative_path)?;

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -10,7 +10,7 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config::{firmware_prefix, sys_fs_prefix};
+use crate::config::system_config::{firmware_prefix, sys_fs_prefix};
 use crate::error::FpgadError;
 use crate::platforms::platform::Fpga;
 use crate::system_io::{fs_read, fs_write};

--- a/src/platforms/universal_components/universal_overlay_handler.rs
+++ b/src/platforms/universal_components/universal_overlay_handler.rs
@@ -10,7 +10,7 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config::system_config::{CONFIG_FS_PREFIX, config_fs_prefix};
+use crate::config::system_config;
 use crate::error::FpgadError;
 use crate::platforms::platform::OverlayHandler;
 use crate::system_io::{extract_filename, fs_create_dir, fs_read, fs_remove_dir, fs_write};
@@ -22,7 +22,8 @@ use std::path::{Path, PathBuf};
 /// device, overlay or bitstream, and so the handle is specified by the user here and the rest
 /// is fixed.
 fn construct_overlay_fs_path(overlay_handle: &str) -> PathBuf {
-    let prefix = config_fs_prefix().unwrap_or_else(|_| CONFIG_FS_PREFIX.to_string());
+    let prefix = system_config::overlay_control_dir()
+        .unwrap_or_else(|_| system_config::OVERLAY_CONTROL_DIR.to_string());
     let overlay_fs_path = PathBuf::from(prefix).join(overlay_handle);
     trace!("overlay_fs_path will be {overlay_fs_path:?}");
     overlay_fs_path

--- a/src/platforms/universal_components/universal_overlay_handler.rs
+++ b/src/platforms/universal_components/universal_overlay_handler.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 /// device, overlay or bitstream, and so the handle is specified by the user here and the rest
 /// is fixed.
 fn construct_overlay_fs_path(overlay_handle: &str) -> PathBuf {
-    let overlay_fs_path = PathBuf::from(config::CONFIGFS_PREFIX).join(overlay_handle);
+    let overlay_fs_path = PathBuf::from(config::system_config().config_fs_prefix()).join(overlay_handle);
     trace!("overlay_fs_path will be {overlay_fs_path:?}");
     overlay_fs_path
 }

--- a/src/platforms/universal_components/universal_overlay_handler.rs
+++ b/src/platforms/universal_components/universal_overlay_handler.rs
@@ -10,7 +10,7 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config;
+use crate::config::{CONFIG_FS_PREFIX, config_fs_prefix};
 use crate::error::FpgadError;
 use crate::platforms::platform::OverlayHandler;
 use crate::system_io::{extract_filename, fs_create_dir, fs_read, fs_remove_dir, fs_write};
@@ -22,8 +22,8 @@ use std::path::{Path, PathBuf};
 /// device, overlay or bitstream, and so the handle is specified by the user here and the rest
 /// is fixed.
 fn construct_overlay_fs_path(overlay_handle: &str) -> PathBuf {
-    let overlay_fs_path =
-        PathBuf::from(config::system_config().config_fs_prefix()).join(overlay_handle);
+    let prefix = config_fs_prefix().unwrap_or_else(|_| CONFIG_FS_PREFIX.to_string());
+    let overlay_fs_path = PathBuf::from(prefix).join(overlay_handle);
     trace!("overlay_fs_path will be {overlay_fs_path:?}");
     overlay_fs_path
 }

--- a/src/platforms/universal_components/universal_overlay_handler.rs
+++ b/src/platforms/universal_components/universal_overlay_handler.rs
@@ -22,7 +22,8 @@ use std::path::{Path, PathBuf};
 /// device, overlay or bitstream, and so the handle is specified by the user here and the rest
 /// is fixed.
 fn construct_overlay_fs_path(overlay_handle: &str) -> PathBuf {
-    let overlay_fs_path = PathBuf::from(config::system_config().config_fs_prefix()).join(overlay_handle);
+    let overlay_fs_path =
+        PathBuf::from(config::system_config().config_fs_prefix()).join(overlay_handle);
     trace!("overlay_fs_path will be {overlay_fs_path:?}");
     overlay_fs_path
 }
@@ -41,8 +42,7 @@ impl UniversalOverlayHandler {
     fn check_source_path(&self, source_path: &Path) -> Result<(), FpgadError> {
         if !source_path.exists() | source_path.is_dir() {
             return Err(FpgadError::Argument(format!(
-                "Overlay file '{:?}' has invalid path.",
-                source_path
+                "Overlay file '{source_path:?}' has invalid path."
             )));
         }
         trace!("{source_path:?} appears to be valid overlay source");
@@ -50,14 +50,14 @@ impl UniversalOverlayHandler {
     }
     fn get_vfs_status(&self) -> Result<String, FpgadError> {
         let status_path = self.overlay_fs_path()?.join("status");
-        trace!("Reading from {:?}", status_path);
+        trace!("Reading from {status_path:?}");
         fs_read(&status_path).map(|s| s.trim_end_matches('\n').to_string())
     }
     /// Read path from <overlay_fs_path>/path file and verify that what was meant to be applied
     /// was applied.
     fn get_vfs_path(&self) -> Result<String, FpgadError> {
         let path_path = self.overlay_fs_path()?.join("path");
-        trace!("Reading from {:?}", path_path);
+        trace!("Reading from {path_path:?}");
         fs_read(&path_path).map(|s| s.trim_end_matches('\n').to_string())
     }
 
@@ -67,11 +67,10 @@ impl UniversalOverlayHandler {
         let path_file_contents = self.get_vfs_path()?;
         let dtbo_file_name = extract_filename(source_path)?;
         if path_file_contents.contains(dtbo_file_name) {
-            info!("overlay path contents is valid: '{}'", path_file_contents);
+            info!("overlay path contents is valid: '{path_file_contents}'");
         } else {
             return Err(FpgadError::OverlayStatus(format!(
-                "When trying to apply overlay '{}', the resulting vfs path contained '{}'",
-                dtbo_file_name, path_file_contents
+                "When trying to apply overlay '{dtbo_file_name}', the resulting vfs path contained '{path_file_contents}'"
             )));
         }
 
@@ -82,8 +81,7 @@ impl UniversalOverlayHandler {
             }
             false => {
                 return Err(FpgadError::OverlayStatus(format!(
-                    "After writing to configfs, overlay status does not show 'applied'. Instead it is '{}'",
-                    status
+                    "After writing to configfs, overlay status does not show 'applied'. Instead it is '{status}'"
                 )));
             }
         }
@@ -109,7 +107,7 @@ impl OverlayHandler for UniversalOverlayHandler {
         }
 
         fs_create_dir(overlay_fs_path)?;
-        trace!("Created dir {:?}", overlay_fs_path);
+        trace!("Created dir {overlay_fs_path:?}");
 
         let overlay_path_file = overlay_fs_path.join("path");
         if !overlay_path_file.exists() {
@@ -124,10 +122,7 @@ impl OverlayHandler for UniversalOverlayHandler {
         let dtbo_file_name = extract_filename(source_path)?;
         match fs_write(&overlay_path_file, false, dtbo_file_name) {
             Ok(_) => {
-                trace!(
-                    "'{}' successfully written to {:?}",
-                    dtbo_file_name, overlay_path_file
-                );
+                trace!("'{dtbo_file_name}' successfully written to {overlay_path_file:?}");
             }
             Err(e) => return Err(e),
         }
@@ -154,7 +149,7 @@ impl OverlayHandler for UniversalOverlayHandler {
         };
         let path = self.get_vfs_path()?;
         let status = self.get_vfs_status()?;
-        Ok(format!("{:?} {}", path, status))
+        Ok(format!("{path:?} {status}"))
     }
 
     /// Checks that the overlay_fs_path is stored at time of call and returns it if so (unwraps Option into Result)

--- a/src/platforms/universal_components/universal_overlay_handler.rs
+++ b/src/platforms/universal_components/universal_overlay_handler.rs
@@ -10,7 +10,7 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::config::{CONFIG_FS_PREFIX, config_fs_prefix};
+use crate::config::system_config::{CONFIG_FS_PREFIX, config_fs_prefix};
 use crate::error::FpgadError;
 use crate::platforms::platform::OverlayHandler;
 use crate::system_io::{extract_filename, fs_create_dir, fs_read, fs_remove_dir, fs_write};

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 
 /// Convenient wrapper for reading the contents of `file_path` to String
 pub fn fs_read(file_path: &Path) -> Result<String, FpgadError> {
-    trace!("Attempting to read from {:?}", file_path);
+    trace!("Attempting to read from {file_path:?}");
     let mut buf: String = String::new();
     let result = OpenOptions::new()
         .read(true)
@@ -64,11 +64,11 @@ pub fn fs_write(file_path: &Path, create: bool, value: impl AsRef<str>) -> Resul
 
 /// Convenient wrapper for recursively creating directories up to `path`
 pub fn fs_create_dir(path: &Path) -> Result<(), FpgadError> {
-    trace!("Attempting to Create '{:?}'", path);
+    trace!("Attempting to Create '{path:?}'");
     let result = create_dir_all(path);
     match result {
         Ok(_) => {
-            trace!("Directory created at {:?}.", path);
+            trace!("Directory created at {path:?}.");
             Ok(())
         }
         Err(e) => Err(FpgadError::IOCreate {
@@ -80,11 +80,11 @@ pub fn fs_create_dir(path: &Path) -> Result<(), FpgadError> {
 
 /// Convenient wrapper for deleting an "empty" directory - works for overlayfs
 pub fn fs_remove_dir(path: &Path) -> Result<(), FpgadError> {
-    trace!("Attempting to delete '{:?}'", path);
+    trace!("Attempting to delete '{path:?}'");
     let result = remove_dir(path);
     match result {
         Ok(_) => {
-            trace!("Deleted {:?}", path);
+            trace!("Deleted {path:?}");
             Ok(())
         }
         Err(e) => Err(FpgadError::IODelete {
@@ -97,7 +97,7 @@ pub fn fs_remove_dir(path: &Path) -> Result<(), FpgadError> {
 /// Helper function to extract the filename from a path and wrap the errors
 pub fn extract_filename(path: &Path) -> Result<&str, FpgadError> {
     path.file_name()
-        .ok_or_else(|| FpgadError::Internal(format!("No filename in path: {:?}", path)))?
+        .ok_or_else(|| FpgadError::Internal(format!("No filename in path: {path:?}")))?
         .to_str()
-        .ok_or_else(|| FpgadError::Internal(format!("Filename not UTF-8: {:?}", path)))
+        .ok_or_else(|| FpgadError::Internal(format!("Filename not UTF-8: {path:?}")))
 }

--- a/tests/threadsafe/test_config_thread_stress.sh
+++ b/tests/threadsafe/test_config_thread_stress.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+
+
+NUM_WORKERS=50
+
+WRITER_CMD='sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetConfigFsPrefix s "/sys/kernel/config/device-tree/overlays/'
+
+READER_CMD='sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetConfigFsPrefix'
+
+# Spawn
+for i in $(seq 1 $NUM_WORKERS); do
+    eval "$WRITER_CMD$i\"" &
+    eval "$READER_CMD" &
+done
+
+wait
+
+echo "Finished running $((NUM_WORKERS)) concurrent D-Bus calls."

--- a/tests/threadsafe/test_config_thread_stress.sh
+++ b/tests/threadsafe/test_config_thread_stress.sh
@@ -3,9 +3,9 @@
 
 NUM_WORKERS=50
 
-WRITER_CMD='sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetConfigFsPrefix s "/sys/kernel/config/device-tree/overlays/'
+WRITER_CMD='sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetOverlayControlDir s "/sys/kernel/config/device-tree/overlays/'
 
-READER_CMD='sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetConfigFsPrefix'
+READER_CMD='sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetOverlayControlDir'
 
 # Spawn
 for i in $(seq 1 $NUM_WORKERS); do


### PR DESCRIPTION
This PR implements:
- a mechanism to load a configuration from `/etc/fpgad/config.toml` and "/usr/lib/fpgad/config.toml"
- a way to change the current confguration via dbus
- backup hardcoded paths in case of mutex failures or lacking configuration data in files
- a config file heirarchy with user defined values in /etc/ overriding vendor defined in /usr/lib/ overriding hardcoded defaults

It does not implement:
- a way to store/edit the current config.toml file from the application itself. Maybe we won't ever do this. 
- a default bitstream/overlay path
