### PR TITLE
dbus: implement get_platform_type and get_platform_types interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonic
 busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetFpgaFlags s "fpga0"
 
 busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetOverlayStatus ss "fpga0" "fpga0"
+
+busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetPlatformType s "fpga0"
+busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetPlatformTypes 
 ```
 
 ### Control (privileged)

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,8 @@ pub enum FpgadError {
     IOCreate { file: PathBuf, e: std::io::Error },
     #[error("FpgadError::IODelete: An IO error occurred when deleting {file:?}: {e}")]
     IODelete { file: PathBuf, e: std::io::Error },
+    #[error("FpgadError::IOReadDir: An IO error occurred when reading directory {dir:?}: {e}")]
+    IOReadDir { dir: PathBuf, e: std::io::Error },
     #[error("FpgadError::Internal: An Internal error occurred: {0}")]
     Internal(String),
 }

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -13,7 +13,7 @@
 use crate::config;
 use crate::error::FpgadError;
 use crate::platforms::universal::UniversalPlatform;
-use crate::system_io::fs_read;
+use crate::system_io::{fs_read, fs_read_dir};
 use log::{error, info, trace, warn};
 use std::path::Path;
 
@@ -30,15 +30,12 @@ const PLATFORM_SUBSTRINGS: &[(&str, PlatformType)] = &[
 ];
 
 /// Scans /sys/class/fpga_manager/ for all present device nodes and returns a Vec of their handles
-#[allow(dead_code)]
-pub fn list_fpga_managers() -> Vec<String> {
-    std::fs::read_dir(config::SYSFS_PREFIX)
-        .map(|iter| {
-            iter.filter_map(Result::ok)
-                .map(|entry| entry.file_name().to_string_lossy().into_owned())
-                .collect()
-        })
-        .unwrap_or_default()
+pub fn list_fpga_managers() -> Result<Vec<String>, FpgadError> {
+    let prefix = config::SYSFS_PREFIX;
+    if prefix.is_empty() {
+        return Ok(vec!["".to_string()]);
+    };
+    fs_read_dir(prefix.as_ref())
 }
 
 /// A sysfs map of an fpga in fpga_manager class.
@@ -95,7 +92,21 @@ pub trait OverlayHandler {
     fn overlay_fs_path(&self) -> Result<&Path, FpgadError>;
 }
 
-fn discover_platform_type(device_handle: &str) -> PlatformType {
+fn match_platform_string(platform_string: &str) -> PlatformType {
+    for (substr, platform) in PLATFORM_SUBSTRINGS {
+        if platform_string.contains(substr) {
+            trace!("Found '{substr}'");
+            return *platform;
+        }
+    }
+    warn!(
+        "FPGAd could not match {platform_string} to a known platform.\
+    Using 'Universal'"
+    );
+    PlatformType::Universal
+}
+
+pub fn read_compatible_string(device_handle: &str) -> Result<String, FpgadError> {
     let compat_string = match fs_read(
         &Path::new(config::SYSFS_PREFIX)
             .join(device_handle)
@@ -103,33 +114,28 @@ fn discover_platform_type(device_handle: &str) -> PlatformType {
     ) {
         Err(e) => {
             error!(
-                "Failed to read platform from {:?}: {}\n\
+                "Failed to read platform from {device_handle:?}: {e}\n\
                 Universal will be used as platform type.",
-                device_handle, e
             );
-            return PlatformType::Universal;
+            return Ok("universal".to_string());
         }
-        Ok(s) => s,
+        Ok(s) => {
+            trace!("{s}");
+            // often driver virtual files contain null terminated strings instead of EOF terminated.
+            s.trim_end_matches('\0').to_string()
+        }
     };
-    trace!("Found compatibility string: '{}'", compat_string);
-
-    for (substr, platform) in PLATFORM_SUBSTRINGS {
-        if compat_string.contains(substr) {
-            trace!("Found '{substr}'");
-            return *platform;
-        }
-    }
-
-    warn!(
-        "FPGAd could not match {compat_string} for {device_handle} to a known platform.\
-    Using 'Universal'"
-    );
-    PlatformType::Universal
+    Ok(compat_string)
 }
 
-pub fn new_platform(device_handle: &str) -> impl Platform {
-    let platform_name = discover_platform_type(device_handle);
-    match platform_name {
+fn discover_platform_type(device_handle: &str) -> Result<PlatformType, FpgadError> {
+    let compat_string = read_compatible_string(device_handle)?;
+    trace!("Found compatibility string: '{compat_string}'");
+    Ok(match_platform_string(&compat_string))
+}
+
+pub fn new_platform(platform_type: PlatformType) -> impl Platform {
+    match platform_type {
         PlatformType::Universal => {
             info!("Using platform: Universal");
             UniversalPlatform::new()
@@ -144,6 +150,15 @@ pub fn new_platform(device_handle: &str) -> impl Platform {
         }
     }
 }
+
+pub fn platform_for_device(device_handle: &str) -> Result<impl Platform, FpgadError> {
+    Ok(new_platform(discover_platform_type(device_handle)?))
+}
+
+pub fn platform_for_known_platform(platform_string: &str) -> impl Platform {
+    new_platform(match_platform_string(platform_string))
+}
+
 pub trait Platform {
     #[allow(dead_code)]
     /// gets the name of the Platform type e.g. Universal or ZynqMP

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -94,6 +94,27 @@ pub fn fs_remove_dir(path: &Path) -> Result<(), FpgadError> {
     }
 }
 
+/// Convenient wrapper for reading contents of a directory
+pub fn fs_read_dir(dir: &Path) -> Result<Vec<String>, FpgadError> {
+    trace!("Attempting to read directory '{dir:?}'");
+    std::fs::read_dir(dir).map_or_else(
+        |e| {
+            Err(FpgadError::IOReadDir {
+                dir: dir.to_owned(),
+                e,
+            })
+        },
+        |iter| {
+            let ret = iter
+                .filter_map(Result::ok)
+                .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                .collect();
+            trace!("Dir reading done.");
+            Ok(ret)
+        },
+    )
+}
+
 /// Helper function to extract the filename from a path and wrap the errors
 pub fn extract_filename(path: &Path) -> Result<&str, FpgadError> {
     path.file_name()


### PR DESCRIPTION
get_platform_type takes a device_handle and returns its platform compat string
get_platform_types returns a map of all device handles to their compat strings

also fixed fpga flags to be u32 as it should be (linux source code's type for it)

spotted a lacking trace! in fs_read