### PR TITLE
platforms: use u32 for fpga flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +729,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
 name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,17 +808,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ members = ["cli"]
 [dependencies]
 log = "0.4.27"
 env_logger = "0.11.8"
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.46.0", features = ["full"] }
 zbus = { version = "5.5.0", default-features = false, features = ["tokio"] }
 thiserror = "2.0.12"

--- a/src/comm/dbus/control_interface.rs
+++ b/src/comm/dbus/control_interface.rs
@@ -11,11 +11,7 @@ pub struct ControlInterface {}
 
 #[interface(name = "com.canonical.fpgad.control")]
 impl ControlInterface {
-    async fn set_fpga_flags(
-        &self,
-        device_handle: &str,
-        flags: isize,
-    ) -> Result<String, fdo::Error> {
+    async fn set_fpga_flags(&self, device_handle: &str, flags: u32) -> Result<String, fdo::Error> {
         trace!(
             "set_fpga_flags called with name: {} and flags: {}",
             device_handle, flags

--- a/src/comm/dbus/control_interface.rs
+++ b/src/comm/dbus/control_interface.rs
@@ -1,78 +1,13 @@
-// This file is part of fpgad, an application to manage FPGA subsystem together with device-tree and kernel modules.
-//
-// Copyright 2025 Canonical Ltd.
-//
-// SPDX-License-Identifier: GPL-3.0-only
-//
-// fpgad is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 3, as published by the Free Software Foundation.
-//
-// fpgad is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranties of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
-
-use crate::config;
-use crate::error::FpgadError;
-use crate::platforms::platform::{Fpga, OverlayHandler, Platform, new_platform};
+use crate::platforms::platform::Fpga;
+use crate::platforms::platform::OverlayHandler;
+use crate::platforms::platform::Platform;
+use crate::platforms::platform::new_platform;
+use crate::system_io::validate_device_handle;
 use log::trace;
-use std::path::{Path, PathBuf};
-use zbus::fdo;
-use zbus::interface;
+use std::path::Path;
+use zbus::{fdo, interface};
 
-pub struct StatusInterface {}
 pub struct ControlInterface {}
-
-fn validate_device_handle(device_handle: &str) -> Result<(), FpgadError> {
-    if device_handle.is_empty() || !device_handle.is_ascii() {
-        return Err(FpgadError::Argument(format!(
-            "{} is invalid name for fpga device.\
-                fpga name must be compliant with sysfs rules.",
-            device_handle
-        )));
-    }
-    if !PathBuf::from(config::SYSFS_PREFIX)
-        .join(device_handle)
-        .exists()
-    {
-        return Err(FpgadError::Argument(format!(
-            "Device {} not found.",
-            device_handle
-        )));
-    };
-    Ok(())
-}
-
-#[interface(name = "com.canonical.fpgad.status")]
-impl StatusInterface {
-    async fn get_fpga_state(&self, device_handle: &str) -> Result<String, fdo::Error> {
-        trace!("get_fpga_state called with name: {}", device_handle);
-        validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle).fpga(device_handle)?.state()?)
-    }
-
-    async fn get_fpga_flags(&self, device_handle: &str) -> Result<String, fdo::Error> {
-        trace!("get_fpga_flags called with name: {}", device_handle);
-        validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle)
-            .fpga(device_handle)?
-            .flags()
-            .map(|flags| flags.to_string())?)
-    }
-
-    async fn get_overlay_status(
-        &self,
-        device_handle: &str,
-        overlay_handle: &str,
-    ) -> Result<String, fdo::Error> {
-        trace!(
-            "get_overlay_status called with device_handle: {device_handle} and overlay_handle:\
-             {overlay_handle}"
-        );
-        validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle)
-            .overlay_handler(overlay_handle)?
-            .status()?)
-    }
-}
 
 #[interface(name = "com.canonical.fpgad.control")]
 impl ControlInterface {

--- a/src/comm/dbus/mod.rs
+++ b/src/comm/dbus/mod.rs
@@ -10,4 +10,5 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-pub mod interfaces;
+pub mod control_interface;
+pub mod status_interface;

--- a/src/comm/dbus/status_interface.rs
+++ b/src/comm/dbus/status_interface.rs
@@ -1,0 +1,42 @@
+use crate::platforms::platform::Fpga;
+use crate::platforms::platform::OverlayHandler;
+use crate::platforms::platform::Platform;
+use crate::platforms::platform::new_platform;
+use crate::system_io::validate_device_handle;
+use log::trace;
+use zbus::{fdo, interface};
+
+pub struct StatusInterface {}
+
+#[interface(name = "com.canonical.fpgad.status")]
+impl StatusInterface {
+    async fn get_fpga_state(&self, device_handle: &str) -> Result<String, fdo::Error> {
+        trace!("get_fpga_state called with name: {}", device_handle);
+        validate_device_handle(device_handle)?;
+        Ok(new_platform(device_handle).fpga(device_handle)?.state()?)
+    }
+
+    async fn get_fpga_flags(&self, device_handle: &str) -> Result<String, fdo::Error> {
+        trace!("get_fpga_flags called with name: {}", device_handle);
+        validate_device_handle(device_handle)?;
+        Ok(new_platform(device_handle)
+            .fpga(device_handle)?
+            .flags()
+            .map(|flags| flags.to_string())?)
+    }
+
+    async fn get_overlay_status(
+        &self,
+        device_handle: &str,
+        overlay_handle: &str,
+    ) -> Result<String, fdo::Error> {
+        trace!(
+            "get_overlay_status called with device_handle: {device_handle} and overlay_handle:\
+             {overlay_handle}"
+        );
+        validate_device_handle(device_handle)?;
+        Ok(new_platform(device_handle)
+            .overlay_handler(overlay_handle)?
+            .status()?)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,8 @@ pub enum FpgadError {
     IOCreate { file: PathBuf, e: std::io::Error },
     #[error("FpgadError::IODelete: An IO error occurred when deleting {file:?}: {e}")]
     IODelete { file: PathBuf, e: std::io::Error },
+    #[error("FpgadError::IOReadDir: An IO error occurred when reading directory {dir:?}: {e}")]
+    IOReadDir { dir: PathBuf, e: std::io::Error },
     #[error("FpgadError::Internal: An Internal error occurred: {0}")]
     Internal(String),
 }
@@ -49,6 +51,7 @@ impl From<FpgadError> for fdo::Error {
             FpgadError::IOWrite { .. } => fdo::Error::IOError(err.to_string()),
             FpgadError::IOCreate { .. } => fdo::Error::IOError(err.to_string()),
             FpgadError::IODelete { .. } => fdo::Error::IOError(err.to_string()),
+            FpgadError::IOReadDir { .. } => fdo::Error::IOError(err.to_string()),
             _ => fdo::Error::Failed(err.to_string()),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod config;
 mod platforms;
 mod system_io;
 
-use crate::comm::dbus::interfaces::{ControlInterface, StatusInterface};
+use crate::comm::dbus::{control_interface::ControlInterface, status_interface::StatusInterface};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -73,9 +73,9 @@ pub trait Fpga {
     /// get the state of the fpga device
     fn state(&self) -> Result<String, FpgadError>;
     /// get the current flags of the fpga device
-    fn flags(&self) -> Result<isize, FpgadError>;
+    fn flags(&self) -> Result<u32, FpgadError>;
     /// attempt to set the flags of an fpga device
-    fn set_flags(&self, flags: isize) -> Result<(), FpgadError>;
+    fn set_flags(&self, flags: u32) -> Result<(), FpgadError>;
     #[allow(dead_code)]
     /// Directly load the firmware stored in bitstream_path to the device
     fn load_firmware(&self, bitstream_path: &Path) -> Result<(), FpgadError>;

--- a/src/platforms/universal.rs
+++ b/src/platforms/universal.rs
@@ -61,8 +61,7 @@ impl Platform for UniversalPlatform {
 
         if !parent_path.exists() {
             return Err(FpgadError::Argument(format!(
-                "The overlayfs path {:?} doesn't seem to exist.",
-                parent_path
+                "The overlayfs path {parent_path:?} doesn't seem to exist."
             )));
         }
         Ok(handler)

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -70,19 +70,19 @@ impl Fpga for UniversalFPGA {
 
     /// Gets the flags from the hex string stored in the sysfs flags file
     /// e.g. sys/class/fpga_manager/fpga0/flags
-    fn flags(&self) -> Result<isize, FpgadError> {
+    fn flags(&self) -> Result<u32, FpgadError> {
         let flag_path = Path::new(config::SYSFS_PREFIX)
             .join(self.device_handle.clone())
             .join("flags");
         let contents = fs_read(&flag_path)?;
         let trimmed = contents.trim().trim_start_matches("0x");
-        isize::from_str_radix(trimmed, 16)
+        u32::from_str_radix(trimmed, 16)
             .map_err(|_| FpgadError::Flag("Parsing flags failed".into()))
     }
 
     /// Sets the flags in the sysfs flags file (e.g. sys/class/fpga_manager/fpga0/flags)
     /// and verifies the write command stuck by reading it back.
-    fn set_flags(&self, flags: isize) -> Result<(), FpgadError> {
+    fn set_flags(&self, flags: u32) -> Result<(), FpgadError> {
         let flag_path = Path::new(config::SYSFS_PREFIX)
             .join(self.device_handle.clone())
             .join("flags");
@@ -138,8 +138,7 @@ impl Fpga for UniversalFPGA {
 
         let relative_path = stripped_path.to_str().ok_or_else(|| {
             FpgadError::Argument(format!(
-                "Stripped bitstream path {:?} is not valid UTF-8",
-                stripped_path
+                "Stripped bitstream path {stripped_path:?} is not valid UTF-8"
             ))
         })?;
 

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -123,3 +123,23 @@ pub fn fs_read_dir(dir: &Path) -> Result<Vec<String>, FpgadError> {
         },
     )
 }
+
+/// Helper function to check that a device with given handle does exist.
+pub(crate) fn validate_device_handle(device_handle: &str) -> Result<(), FpgadError> {
+    if device_handle.is_empty() || !device_handle.is_ascii() {
+        return Err(FpgadError::Argument(format!(
+            "{device_handle} is invalid name for fpga device.\
+                fpga name must be compliant with sysfs rules."
+        )));
+    }
+    let fpga_managers_dir = config::SYSFS_PREFIX;
+    if !PathBuf::from(fpga_managers_dir)
+        .join(device_handle)
+        .exists()
+    {
+        return Err(FpgadError::Argument(format!(
+            "Device {device_handle} not found."
+        )));
+    };
+    Ok(())
+}


### PR DESCRIPTION
The flags variable is stored as u32 fixed size in linux source code so this should match that. This allows the dbus flags variable to be architecture independent