### PR TITLE
platforms: two minor tweaks - add trace and require hyphen in platform strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,15 +821,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.25"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1011,9 +1011,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ It should be clear to see, then, that compromising the device tree is very power
 
 # To Run Daemon
 
-```
+```shell
 sudo RUST_LOG=trace RUST_BACKTRACE=full ./target/debug/fpgad
 ```
 
-# Configure DBUS:
+# Configure DBUS
 
-```
+```shell
 sudo cp ./data/dbus/com.canonical.fpgad.conf /etc/dbus-1/system.d/
 ```
 
@@ -68,7 +68,7 @@ To remove an overlay simply call:
 
 ### Status (unprivileged)
 
-```
+```shell
 busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetFpgaState s "fpga0"
 
 busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetFpgaFlags s "fpga0"
@@ -81,8 +81,8 @@ busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonic
 
 ### Control (privileged)
 
-```
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control SetFpgaFlags sx "fpga0" 0
+```shell
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control SetFpgaFlags su "fpga0" 0
 
 sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control ApplyOverlay sss "fpga0" "fpga0" "/lib/firmware/k26-starter-kits.dtbo"
 

--- a/README.md
+++ b/README.md
@@ -110,3 +110,23 @@ sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.c
 
 sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control RemoveOverlay ss "fpga0" "fpga0" 
 ```
+
+### Configure
+
+```
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetFirmwareSourceDir
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetFirmwareSourceDir s "/lib/firmware/"
+```
+
+### Example changing FW path
+
+```
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetFirmwareSourceDir s "/lib/firmware/"
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteBitstreamDirect ss "fpga0" "/lib/firmware/k26-starter-kits.bit.bin"
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetFirmwareSourceDir s "/lib/firmware/xilinx/k26-starter-kits"
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteBitstreamDirect ss "fpga0" "/lib/firmware/xilinx/k26-starter-kits/k26_starter_kits.bit.bin"
+```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ sudo RUST_LOG=trace RUST_BACKTRACE=full ./target/debug/fpgad
 sudo cp ./data/dbus/com.canonical.fpgad.conf /etc/dbus-1/system.d/
 ```
 
+# To run on startup
+
+Before installing, confirm that `ExecStart=` in the `.service` file points to the correct executable (e.g.
+`ExecStart=/home/ubuntu/fpgad/target/debug/fpgad`).
+
+To install the service run
+
+```shell
+sudo cp data/systemd/fpgad.service /lib/systemd/system/
+```
+
+To run without restarting
+
+```shell
+sudo systemctl daemon-reexec
+sudo systemctl daemon-reload
+sudo systemctl enable fpgad.service
+sudo systemctl start fpgad.service
+```
+
 # Typical control sequence
 
 #### FPGA only:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonic
 busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetFpgaFlags s "fpga0"
 
 busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetOverlayStatus ss "fpga0" "fpga0"
+
+busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetPlatformType s "fpga0"
+busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetPlatformTypes 
 ```
 
 ### Control (privileged)

--- a/data/systemd/fpgad.service
+++ b/data/systemd/fpgad.service
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# FPGAd provides a strictly confined snap to which user bitstreams snaps can connect.
+# This connections provides a security hardened gateway necessary to load and unload
+# bitstreams to and from devices on Ubuntu core, and is a useful snap interface for
+# classic ubuntu.
+
+[Unit]
+Description=fpgad - FPGA daemon
+Documentation=https://github.com/canonical/fpgad
+
+[Service]
+Type=dbus
+BusName=com.canonical.fpgad
+Environment=RUST_LOG=info
+Environment=RUST_BACKTRACE=1
+ExecStart=/usr/bin/fpgad # change this to point to install loc
+User=root
+Restart=on-failure
+TimeoutStartSec=30
+StandardOutput=journal
+StandardError=journal
+StandardInput=null
+
+[Install]
+WantedBy=multi-user.target

--- a/src/comm/dbus/interfaces.rs
+++ b/src/comm/dbus/interfaces.rs
@@ -22,6 +22,26 @@ pub struct StatusInterface {}
 pub struct ControlInterface {}
 pub struct ConfigureInterface {}
 
+fn validate_device_handle(device_handle: &str) -> Result<(), FpgadError> {
+    if device_handle.is_empty() || !device_handle.is_ascii() {
+        return Err(FpgadError::Argument(format!(
+            "{} is invalid name for fpga device.\
+                fpga name must be compliant with sysfs rules.",
+            device_handle
+        )));
+    }
+    if !PathBuf::from(config::OVERLAY_CONTROL_DIR)
+        .join(device_handle)
+        .exists()
+    {
+        return Err(FpgadError::Argument(format!(
+            "Device {} not found.",
+            device_handle
+        )));
+    };
+    Ok(())
+}
+
 #[interface(name = "com.canonical.fpgad.status")]
 impl StatusInterface {
     async fn get_fpga_state(&self, device_handle: &str) -> Result<String, fdo::Error> {

--- a/src/comm/dbus/interfaces.rs
+++ b/src/comm/dbus/interfaces.rs
@@ -9,7 +9,6 @@
 // fpgad is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranties of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
-
 use crate::config;
 use crate::error::FpgadError;
 use crate::platforms::platform::{
@@ -109,7 +108,7 @@ impl ControlInterface {
     async fn set_fpga_flags(
         &self,
         device_handle: &str,
-        flags: isize,
+        flags: u32,
     ) -> Result<String, fdo::Error> {
         trace!("set_fpga_flags called with name: {device_handle} and flags: {flags}");
         validate_device_handle(device_handle)?;

--- a/src/comm/dbus/interfaces.rs
+++ b/src/comm/dbus/interfaces.rs
@@ -20,6 +20,7 @@ use zbus::interface;
 
 pub struct StatusInterface {}
 pub struct ControlInterface {}
+pub struct ConfigureInterface {}
 
 #[interface(name = "com.canonical.fpgad.status")]
 impl StatusInterface {
@@ -152,5 +153,42 @@ impl ControlInterface {
         Ok(format!(
             "{overlay_handle} removed by deleting {overlay_fs_path:?}"
         ))
+    }
+}
+
+fn write_firmware_source_dir(new_path: &str) -> Result<(), FpgadError> {
+    trace!(
+        "Writing fw prefix {} to {}",
+        new_path,
+        config::FIRMWARE_LOC_CONTROL_PATH
+    );
+    let fw_lookup_override = Path::new(config::FIRMWARE_LOC_CONTROL_PATH);
+    fs_write(fw_lookup_override, false, new_path)
+}
+
+fn read_firmware_source_dir() -> Result<(String), FpgadError> {
+    trace!(
+        "Reading fw prefix from {}",
+        config::FIRMWARE_LOC_CONTROL_PATH
+    );
+    let fw_lookup_override = Path::new(config::FIRMWARE_LOC_CONTROL_PATH);
+    fs_read(fw_lookup_override)
+}
+
+pub fn set_firmware_source_dir(new_path: &str) -> Result<(), FpgadError> {
+    // TODO: checks for exist?
+    write_firmware_source_dir(new_path)
+}
+
+#[interface(name = "com.canonical.fpgad.configure")]
+impl ConfigureInterface {
+    async fn get_firmware_source_dir(&self) -> Result<String, fdo::Error> {
+        trace!("get_firmware_source_dir called");
+        Ok(read_firmware_source_dir()?)
+    }
+    async fn set_firmware_source_dir(&self, new_path: &str) -> Result<String, fdo::Error> {
+        trace!("set_firmware_source_dir called with prefix: {new_path}");
+        set_firmware_source_dir(new_path)?;
+        Ok(format!("firmware_source_dir set to {new_path}"))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 // TODO: this should be provided by the config
-pub static FW_PREFIX: &str = "/lib/firmware/";
-pub static SYSFS_PREFIX: &str = "/sys/class/fpga_manager/";
-pub static CONFIGFS_PREFIX: &str = "/sys/kernel/config/device-tree/overlays/";
+pub static FIRMWARE_SOURCE_DIR: &str = "/lib/firmware/";
+pub static FPGA_MANAGERS_DIR: &str = "/sys/class/fpga_manager/";
+pub static OVERLAY_CONTROL_DIR: &str = "/sys/kernel/config/device-tree/overlays/";
 pub static FIRMWARE_LOC_CONTROL_PATH: &str = "/sys/module/firmware_class/parameters/path";

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,3 +2,4 @@
 pub static FW_PREFIX: &str = "/lib/firmware/";
 pub static SYSFS_PREFIX: &str = "/sys/class/fpga_manager/";
 pub static CONFIGFS_PREFIX: &str = "/sys/kernel/config/device-tree/overlays/";
+pub static FIRMWARE_LOC_CONTROL_PATH: &str = "/sys/module/firmware_class/parameters/path";

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,8 @@ pub enum FpgadError {
     IOCreate { file: PathBuf, e: std::io::Error },
     #[error("FpgadError::IODelete: An IO error occurred when deleting {file:?}: {e}")]
     IODelete { file: PathBuf, e: std::io::Error },
+    #[error("FpgadError::IOReadDir: An IO error occurred when reading directory {dir:?}: {e}")]
+    IOReadDir { dir: PathBuf, e: std::io::Error },
     #[error("FpgadError::Internal: An Internal error occurred: {0}")]
     Internal(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,6 @@ use crate::comm::dbus::interfaces::{ControlInterface, StatusInterface};
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    // Upon load, the daemon will search each fpga device and determine what platform it is
-    // based on its name in /sys/class/fpga_manager/{device}/name
     let status_interface = StatusInterface {};
     let control_interface = ControlInterface {};
 

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -21,12 +21,16 @@ use std::path::Path;
 enum PlatformType {
     Universal,
     ZynqMP,
+    Zynq, // no mp
     Versal,
 }
 
+//  TODO: this may become generic `xilinx,` for all xilinx devices instead, depending on what
+//   the softener code ends up looking like.
 const PLATFORM_SUBSTRINGS: &[(&str, PlatformType)] = &[
-    ("zynqmp", PlatformType::ZynqMP),
-    ("versal", PlatformType::Versal),
+    ("zynqmp-", PlatformType::ZynqMP),
+    ("versal-", PlatformType::Versal),
+    ("zynq-", PlatformType::Zynq),
 ];
 
 /// Scans /sys/class/fpga_manager/ for all present device nodes and returns a Vec of their handles
@@ -139,6 +143,10 @@ pub fn new_platform(platform_type: PlatformType) -> impl Platform {
     match platform_type {
         PlatformType::Universal => {
             info!("Using platform: Universal");
+            UniversalPlatform::new()
+        }
+        PlatformType::Zynq => {
+            warn!("Zynq not implemented yet: using Universal");
             UniversalPlatform::new()
         }
         PlatformType::ZynqMP => {

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -13,7 +13,7 @@
 use crate::config;
 use crate::error::FpgadError;
 use crate::platforms::universal::UniversalPlatform;
-use crate::system_io::fs_read;
+use crate::system_io::{fs_read, fs_read_dir};
 use log::{error, info, trace, warn};
 use std::path::Path;
 
@@ -30,15 +30,12 @@ const PLATFORM_SUBSTRINGS: &[(&str, PlatformType)] = &[
 ];
 
 /// Scans /sys/class/fpga_manager/ for all present device nodes and returns a Vec of their handles
-#[allow(dead_code)]
-pub fn list_fpga_managers() -> Vec<String> {
-    std::fs::read_dir(config::SYSFS_PREFIX)
-        .map(|iter| {
-            iter.filter_map(Result::ok)
-                .map(|entry| entry.file_name().to_string_lossy().into_owned())
-                .collect()
-        })
-        .unwrap_or_default()
+pub fn list_fpga_managers() -> Result<Vec<String>, FpgadError> {
+    let prefix = config::SYSFS_PREFIX;
+    if prefix.is_empty() {
+        return Ok(vec!["".to_string()]);
+    };
+    fs_read_dir(prefix.as_ref())
 }
 
 /// A sysfs map of an fpga in fpga_manager class.
@@ -95,7 +92,21 @@ pub trait OverlayHandler {
     fn overlay_fs_path(&self) -> Result<&Path, FpgadError>;
 }
 
-fn discover_platform_type(device_handle: &str) -> PlatformType {
+fn match_platform_string(platform_string: &str) -> PlatformType {
+    for (substr, platform) in PLATFORM_SUBSTRINGS {
+        if platform_string.contains(substr) {
+            trace!("Found '{substr}'");
+            return *platform;
+        }
+    }
+    warn!(
+        "FPGAd could not match {platform_string} to a known platform.\
+    Using 'Universal'"
+    );
+    PlatformType::Universal
+}
+
+pub fn read_compatible_string(device_handle: &str) -> Result<String, FpgadError> {
     let compat_string = match fs_read(
         &Path::new(config::SYSFS_PREFIX)
             .join(device_handle)
@@ -103,33 +114,28 @@ fn discover_platform_type(device_handle: &str) -> PlatformType {
     ) {
         Err(e) => {
             error!(
-                "Failed to read platform from {:?}: {}\n\
+                "Failed to read platform from {device_handle:?}: {e}\n\
                 Universal will be used as platform type.",
-                device_handle, e
             );
-            return PlatformType::Universal;
+            return Ok("universal".to_string());
         }
-        Ok(s) => s,
+        Ok(s) => {
+            trace!("{s}");
+            // often driver virtual files contain null terminated strings instead of EOF terminated.
+            s.trim_end_matches('\0').to_string()
+        }
     };
-    trace!("Found compatibility string: '{}'", compat_string);
-
-    for (substr, platform) in PLATFORM_SUBSTRINGS {
-        if compat_string.contains(substr) {
-            trace!("Found '{substr}'");
-            return *platform;
-        }
-    }
-
-    warn!(
-        "FPGAd could not match {compat_string} for {device_handle} to a known platform.\
-    Using 'Universal'"
-    );
-    PlatformType::Universal
+    Ok(compat_string)
 }
 
-pub fn new_platform(device_handle: &str) -> impl Platform {
-    let platform_name = discover_platform_type(device_handle);
-    match platform_name {
+fn discover_platform_type(device_handle: &str) -> Result<PlatformType, FpgadError> {
+    let compat_string = read_compatible_string(device_handle)?;
+    trace!("Found compatibility string: '{compat_string}'");
+    Ok(match_platform_string(&compat_string))
+}
+
+pub fn new_platform(platform_type: PlatformType) -> impl Platform {
+    match platform_type {
         PlatformType::Universal => {
             info!("Using platform: Universal");
             UniversalPlatform::new()
@@ -144,6 +150,15 @@ pub fn new_platform(device_handle: &str) -> impl Platform {
         }
     }
 }
+
+pub fn platform_for_device(device_handle: &str) -> Result<impl Platform, FpgadError> {
+    Ok(new_platform(discover_platform_type(device_handle)?))
+}
+
+pub fn platform_for_known_platform(platform_string: &str) -> impl Platform {
+    new_platform(match_platform_string(platform_string))
+}
+
 pub trait Platform {
     #[allow(dead_code)]
     /// gets the name of the Platform type e.g. Universal or ZynqMP

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -70,9 +70,9 @@ pub trait Fpga {
     /// get the state of the fpga device
     fn state(&self) -> Result<String, FpgadError>;
     /// get the current flags of the fpga device
-    fn flags(&self) -> Result<isize, FpgadError>;
+    fn flags(&self) -> Result<u32, FpgadError>;
     /// attempt to set the flags of an fpga device
-    fn set_flags(&self, flags: isize) -> Result<(), FpgadError>;
+    fn set_flags(&self, flags: u32) -> Result<(), FpgadError>;
     #[allow(dead_code)]
     /// Directly load the firmware stored in bitstream_path to the device
     fn load_firmware(&self, bitstream_path: &Path) -> Result<(), FpgadError>;

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -31,7 +31,7 @@ const PLATFORM_SUBSTRINGS: &[(&str, PlatformType)] = &[
 
 /// Scans /sys/class/fpga_manager/ for all present device nodes and returns a Vec of their handles
 pub fn list_fpga_managers() -> Result<Vec<String>, FpgadError> {
-    let prefix = config::SYSFS_PREFIX;
+    let prefix = config::OVERLAY_CONTROL_DIR;
     if prefix.is_empty() {
         return Ok(vec!["".to_string()]);
     };
@@ -106,7 +106,7 @@ fn match_platform_string(platform_string: &str) -> Result<PlatformType, FpgadErr
 
 pub fn read_compatible_string(device_handle: &str) -> Result<String, FpgadError> {
     let compat_string = match fs_read(
-        &Path::new(config::SYSFS_PREFIX)
+        &Path::new(config::OVERLAY_CONTROL_DIR)
             .join(device_handle)
             .join("of_node/compatible"),
     ) {

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -70,19 +70,19 @@ impl Fpga for UniversalFPGA {
 
     /// Gets the flags from the hex string stored in the sysfs flags file
     /// e.g. sys/class/fpga_manager/fpga0/flags
-    fn flags(&self) -> Result<isize, FpgadError> {
+    fn flags(&self) -> Result<u32, FpgadError> {
         let flag_path = Path::new(config::SYSFS_PREFIX)
             .join(self.device_handle.clone())
             .join("flags");
         let contents = fs_read(&flag_path)?;
         let trimmed = contents.trim().trim_start_matches("0x");
-        isize::from_str_radix(trimmed, 16)
+        u32::from_str_radix(trimmed, 16)
             .map_err(|_| FpgadError::Flag("Parsing flags failed".into()))
     }
 
     /// Sets the flags in the sysfs flags file (e.g. sys/class/fpga_manager/fpga0/flags)
     /// and verifies the write command stuck by reading it back.
-    fn set_flags(&self, flags: isize) -> Result<(), FpgadError> {
+    fn set_flags(&self, flags: u32) -> Result<(), FpgadError> {
         let flag_path = Path::new(config::SYSFS_PREFIX)
             .join(self.device_handle.clone())
             .join("flags");
@@ -109,7 +109,6 @@ impl Fpga for UniversalFPGA {
             },
             Err(e) => return Err(e),
         };
-
         match self.flags() {
             Ok(returned_flags) if returned_flags == flags => Ok(()),
             Ok(returned_flags) => Err(FpgadError::Flag(format!(
@@ -138,8 +137,7 @@ impl Fpga for UniversalFPGA {
 
         let relative_path = stripped_path.to_str().ok_or_else(|| {
             FpgadError::Argument(format!(
-                "Stripped bitstream path {:?} is not valid UTF-8",
-                stripped_path
+                "Stripped bitstream path {stripped_path:?} is not valid UTF-8"
             ))
         })?;
 

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -61,7 +61,7 @@ impl Fpga for UniversalFPGA {
     ///
     /// returns: Result<String, FpgadError>
     fn state(&self) -> Result<String, FpgadError> {
-        let state_path = Path::new(config::SYSFS_PREFIX)
+        let state_path = Path::new(config::OVERLAY_CONTROL_DIR)
             .join(self.device_handle.clone())
             .join("state");
         trace!("reading {state_path:?}");
@@ -71,7 +71,7 @@ impl Fpga for UniversalFPGA {
     /// Gets the flags from the hex string stored in the sysfs flags file
     /// e.g. sys/class/fpga_manager/fpga0/flags
     fn flags(&self) -> Result<u32, FpgadError> {
-        let flag_path = Path::new(config::SYSFS_PREFIX)
+        let flag_path = Path::new(config::OVERLAY_CONTROL_DIR)
             .join(self.device_handle.clone())
             .join("flags");
         let contents = fs_read(&flag_path)?;
@@ -83,7 +83,7 @@ impl Fpga for UniversalFPGA {
     /// Sets the flags in the sysfs flags file (e.g. sys/class/fpga_manager/fpga0/flags)
     /// and verifies the write command stuck by reading it back.
     fn set_flags(&self, flags: u32) -> Result<(), FpgadError> {
-        let flag_path = Path::new(config::SYSFS_PREFIX)
+        let flag_path = Path::new(config::OVERLAY_CONTROL_DIR)
             .join(self.device_handle.clone())
             .join("flags");
         trace!("Writing '{flags}' to '{flag_path:?}");
@@ -126,12 +126,12 @@ impl Fpga for UniversalFPGA {
     /// Note: always load firmware before overlay.
     fn load_firmware(&self, bitstream_path: &Path) -> Result<(), FpgadError> {
         let stripped_path = bitstream_path
-            .strip_prefix(config::FW_PREFIX)
+            .strip_prefix(config::FIRMWARE_SOURCE_DIR)
             .map_err(|_| {
                 FpgadError::Argument(format!(
                     "Bitstream path {:?} is not under the configured firmware directory '{}'",
                     bitstream_path,
-                    config::FW_PREFIX
+                    config::FIRMWARE_SOURCE_DIR
                 ))
             })?;
 
@@ -141,7 +141,7 @@ impl Fpga for UniversalFPGA {
             ))
         })?;
 
-        let control_path = Path::new(config::SYSFS_PREFIX)
+        let control_path = Path::new(config::OVERLAY_CONTROL_DIR)
             .join(self.device_handle())
             .join("firmware");
         fs_write(&control_path, false, relative_path)?;

--- a/src/platforms/universal_components/universal_overlay_handler.rs
+++ b/src/platforms/universal_components/universal_overlay_handler.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 /// device, overlay or bitstream, and so the handle is specified by the user here and the rest
 /// is fixed.
 fn construct_overlay_fs_path(overlay_handle: &str) -> PathBuf {
-    let overlay_fs_path = PathBuf::from(config::CONFIGFS_PREFIX).join(overlay_handle);
+    let overlay_fs_path = PathBuf::from(config::OVERLAY_CONTROL_DIR).join(overlay_handle);
     trace!("overlay_fs_path will be {overlay_fs_path:?}");
     overlay_fs_path
 }

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -27,9 +27,11 @@ pub fn fs_read(file_path: &Path) -> Result<String, FpgadError> {
         .open(file_path)
         .and_then(|mut f| f.read_to_string(&mut buf));
 
-    // do checks on the data we got if necessary
     match result {
-        Ok(_) => Ok(buf),
+        Ok(_) => {
+            trace!("Reading done");
+            Ok(buf)
+        }
         Err(e) => Err(FpgadError::IORead {
             file: file_path.into(),
             e,

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -94,6 +94,27 @@ pub fn fs_remove_dir(path: &Path) -> Result<(), FpgadError> {
     }
 }
 
+/// Convenient wrapper for reading contents of a directory
+pub fn fs_read_dir(dir: &Path) -> Result<Vec<String>, FpgadError> {
+    trace!("Attempting to read directory '{dir:?}'");
+    std::fs::read_dir(dir).map_or_else(
+        |e| {
+            Err(FpgadError::IOReadDir {
+                dir: dir.to_owned(),
+                e,
+            })
+        },
+        |iter| {
+            let ret = iter
+                .filter_map(Result::ok)
+                .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                .collect();
+            trace!("Dir reading done.");
+            Ok(ret)
+        },
+    )
+}
+
 /// Helper function to extract the filename from a path and wrap the errors
 pub fn extract_filename(path: &Path) -> Result<&str, FpgadError> {
     path.file_name()

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -10,12 +10,13 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
+use crate::config;
 use crate::error::FpgadError;
 use log::trace;
 use std::fs::OpenOptions;
 use std::fs::{create_dir_all, remove_dir};
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Convenient wrapper for reading the contents of `file_path` to String
 pub fn fs_read(file_path: &Path) -> Result<String, FpgadError> {
@@ -121,4 +122,24 @@ pub fn extract_filename(path: &Path) -> Result<&str, FpgadError> {
         .ok_or_else(|| FpgadError::Internal(format!("No filename in path: {:?}", path)))?
         .to_str()
         .ok_or_else(|| FpgadError::Internal(format!("Filename not UTF-8: {:?}", path)))
+}
+
+/// Helper function to check that a device with given handle does exist.
+pub(crate) fn validate_device_handle(device_handle: &str) -> Result<(), FpgadError> {
+    if device_handle.is_empty() || !device_handle.is_ascii() {
+        return Err(FpgadError::Argument(format!(
+            "{device_handle} is invalid name for fpga device.\
+                fpga name must be compliant with sysfs rules."
+        )));
+    }
+    let fpga_managers_dir = config::SYSFS_PREFIX;
+    if !PathBuf::from(fpga_managers_dir)
+        .join(device_handle)
+        .exists()
+    {
+        return Err(FpgadError::Argument(format!(
+            "Device {device_handle} not found."
+        )));
+    };
+    Ok(())
 }

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -132,7 +132,7 @@ pub(crate) fn validate_device_handle(device_handle: &str) -> Result<(), FpgadErr
                 fpga name must be compliant with sysfs rules."
         )));
     }
-    let fpga_managers_dir = config::SYSFS_PREFIX;
+    let fpga_managers_dir = config::FPGA_MANAGERS_DIR;
     if !PathBuf::from(fpga_managers_dir)
         .join(device_handle)
         .exists()


### PR DESCRIPTION
1) add a trace print to fs_read on success to match other fs_* functions
2) the zynq string would match to zynq and zynqmp and so this adds the need for the hyphen, but we may change this to xilinx instead - to discuss
