### PR TITLE
cli: use pretty tables for status

### DIFF
--- a/.git_components.yaml
+++ b/.git_components.yaml
@@ -27,6 +27,7 @@ workflows:
 cli:
   owners:
     - talhaHavadar
+    - artiepoole
 docs:
   owners:
     - artiepoole

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,15 +196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
-name = "cli"
-version = "0.1.0"
-dependencies = [
- "clap",
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +308,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fpga"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "log",
+]
 
 [[package]]
 name = "fpgad"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,8 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
+ "tokio",
+ "zbus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,12 +316,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fpga"
 version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger",
  "log",
+ "tabled",
  "tokio",
  "zbus",
 ]
@@ -545,6 +558,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +625,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -776,6 +822,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +856,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -904,6 +983,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "utf8parse"

--- a/README.md
+++ b/README.md
@@ -23,14 +23,34 @@ It should be clear to see, then, that compromising the device tree is very power
 
 # To Run Daemon
 
-```
+```shell
 sudo RUST_LOG=trace RUST_BACKTRACE=full ./target/debug/fpgad
 ```
 
-# Configure DBUS:
+# Configure DBUS
 
-```
+```shell
 sudo cp ./data/dbus/com.canonical.fpgad.conf /etc/dbus-1/system.d/
+```
+
+# To run on startup
+
+Before installing, confirm that `ExecStart=` in the `.service` file points to the correct executable (e.g.
+`ExecStart=/home/ubuntu/fpgad/target/debug/fpgad`).
+
+To install the service run
+
+```shell
+sudo cp data/systemd/fpgad.service /lib/systemd/system/
+```
+
+To run without restarting
+
+```shell
+sudo systemctl daemon-reexec
+sudo systemctl daemon-reload
+sudo systemctl enable fpgad.service
+sudo systemctl start fpgad.service
 ```
 
 # Typical control sequence
@@ -68,22 +88,50 @@ To remove an overlay simply call:
 
 ### Status (unprivileged)
 
-```
-busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetFpgaState s "fpga0"
+```shell
+busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetFpgaState ss "" "fpga0"
 
-busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetFpgaFlags s "fpga0"
+busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetFpgaFlags ss "" "fpga0"
 
-busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetOverlayStatus ss "fpga0" "fpga0"
+busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetOverlayStatus ss "zynqmp-" "fpga0"
+
+busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetPlatformType s "fpga0"
+
+busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetPlatformTypes 
+
+busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status GetOverlays
 ```
 
 ### Control (privileged)
 
-```
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control SetFpgaFlags sx "fpga0" 0
+```shell
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control SetFpgaFlags ssu "" "fpga0" 0
 
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control ApplyOverlay sss "fpga0" "fpga0" "/lib/firmware/k26-starter-kits.dtbo"
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control ApplyOverlay sss "zynqmp-" "fpga0" "/lib/firmware/k26-starter-kits.dtbo"
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteBitstreamDirect sss "" "fpga0" "/lib/firmware/k26-starter-kits.bit.bin"
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control RemoveOverlay ss "zynqmp-" "fpga0" 
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control LoadDefaults
+```
+
+### Configure
+
+```
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure GetFirmwareSourceDir
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetFirmwareSourceDir s "/lib/firmware/"
+```
+
+### Example changing FW path
+
+```
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetFirmwareSourceDir s "/lib/firmware/"
 
 sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteBitstreamDirect ss "fpga0" "/lib/firmware/k26-starter-kits.bit.bin"
 
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control RemoveOverlay ss "fpga0" "fpga0" 
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/configure com.canonical.fpgad.configure SetFirmwareSourceDir s "/lib/firmware/xilinx/k26-starter-kits"
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteBitstreamDirect ss "fpga0" "/lib/firmware/xilinx/k26-starter-kits/k26_starter_kits.bit.bin"
 ```

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2024"
 clap = { version = "4.5.40", features = ["derive"] }
 env_logger = "0.11.8"
 log = "0.4.27"
+tokio = { version = "1.46.0", features = ["full"] }
+zbus = { version = "5.5.0", default-features = false, features = ["tokio"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cli"
+name = "fpga"
 version = "0.1.0"
 edition = "2024"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,3 +9,4 @@ env_logger = "0.11.8"
 log = "0.4.27"
 tokio = { version = "1.46.0", features = ["full"] }
 zbus = { version = "5.5.0", default-features = false, features = ["tokio"] }
+tabled = "0.20.0"

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,33 @@
+# fpga - FPGAd's CLI application
+
+## Usage
+
+```
+Usage: fpga [OPTIONS] <COMMAND>
+
+Commands:
+  status  Get the status information for the given device handle
+  load    Load a bitstream or an overlay for the given device handle
+  remove  Remove bitstream or an overlay
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --handle <HANDLE>  fpga device `HANDLE` to be used for the operations. Default value for this option is calculated in runtime and the application picks the first available fpga in the system (under /sys/class/fpga_manager)
+  -h, --help             Print help
+
+```
+
+### Status
+
+```shell
+fpga [--handle=<device_handle>] status
+```
+
+## examples (for testing)
+
+### Status
+
+```shell
+./target/debug/fpga status
+./target/debug/fpga --handle=fpga0 status
+```

--- a/cli/README.md
+++ b/cli/README.md
@@ -29,6 +29,12 @@ fpga [--handle=<device_handle>] status
 fpga [--handle=<device_handle>] load ( (overlay <file> [--handle=<handle>]) | (bitstream <file>) )
 ```
 
+### Removing
+
+```shell
+fpga [--handle=<device_handle>] remove ( ( overlay <HANDLE> ) | ( bitstream ) )
+```
+
 ## examples (for testing)
 
 ### Status
@@ -47,4 +53,11 @@ sudo ./target/debug/fpga --handle=fpga0 load bitstream /lib/firmware/k26-starter
 sudo ./target/debug/fpga load overlay /lib/firmware/k26-starter-kits.dtbo
 sudo ./target/debug/fpga load overlay /lib/firmware/k26-starter-kits.dtbo --handle=overlay_handle
 sudo ./target/debug/fpga --handle=fpga0 load overlay /lib/firmware/k26-starter-kits.dtbo --handle=overlay_handle
+```
+
+### Remove
+
+```shell
+sudo ./target/debug/fpga --handle=fpga0 remove overlay
+sudo ./target/debug/fpga --handle=fpga0 remove overlay --handle=overlay_handle
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -23,6 +23,12 @@ Options:
 fpga [--handle=<device_handle>] status
 ```
 
+### Loading
+
+```shell
+fpga [--handle=<device_handle>] load ( (overlay <file> [--handle=<handle>]) | (bitstream <file>) )
+```
+
 ## examples (for testing)
 
 ### Status
@@ -30,4 +36,15 @@ fpga [--handle=<device_handle>] status
 ```shell
 ./target/debug/fpga status
 ./target/debug/fpga --handle=fpga0 status
+```
+
+### Load
+
+```shell
+sudo ./target/debug/fpga load bitstream /lib/firmware/k26-starter-kits.bit.bin
+sudo ./target/debug/fpga --handle=fpga0 load bitstream /lib/firmware/k26-starter-kits.bit.bin
+
+sudo ./target/debug/fpga load overlay /lib/firmware/k26-starter-kits.dtbo
+sudo ./target/debug/fpga load overlay /lib/firmware/k26-starter-kits.dtbo --handle=overlay_handle
+sudo ./target/debug/fpga --handle=fpga0 load overlay /lib/firmware/k26-starter-kits.dtbo --handle=overlay_handle
 ```

--- a/cli/src/load.rs
+++ b/cli/src/load.rs
@@ -1,0 +1,100 @@
+use crate::LoadSubcommand;
+use crate::proxies::control_proxy;
+use crate::status::{
+    call_get_platform_type, call_get_platform_types, get_first_device_handle, get_first_platform,
+};
+use zbus::Connection;
+
+/// Sends the dbus command to load a bitstream
+async fn call_load_bitstream(
+    platform_str: &str,
+    device_handle: &str,
+    file_path: &str,
+) -> Result<String, zbus::Error> {
+    let connection = Connection::system().await?;
+    let proxy = control_proxy::ControlProxy::new(&connection).await?;
+    proxy
+        .write_bitstream_direct(platform_str, device_handle, file_path)
+        .await
+}
+
+/// Sends the dbus command to apply an overlay
+async fn call_apply_overlay(
+    platform: &str,
+    file_path: &str,
+    overlay_handle: &str,
+) -> Result<String, zbus::Error> {
+    let connection = Connection::system().await?;
+    let proxy = control_proxy::ControlProxy::new(&connection).await?;
+    proxy
+        .apply_overlay(platform, overlay_handle, file_path)
+        .await
+}
+
+/// Populates the platform and overlay handle appropriately before calling `call_apply_overlay`
+async fn apply_overlay(
+    dev_handle: &Option<String>,
+    file_path: &str,
+    overlay_handle: &Option<String>,
+) -> Result<String, zbus::Error> {
+    // Determine platform and overlay handle based on provided parameters
+    let (platform, overlay_handle_to_use) = match (dev_handle, overlay_handle) {
+        // Both are provided
+        (Some(dev), Some(overlay)) => (call_get_platform_type(dev).await?, overlay.clone()),
+
+        // dev_handle provided, overlay_handle not provided so use device name as overlay handle
+        (Some(dev), None) => {
+            let platform = call_get_platform_type(dev).await?;
+            (platform, dev.clone())
+        }
+        // dev_handle not provided, so use first platform
+        (None, Some(overlay)) => {
+            let platform = get_first_platform().await?;
+            (platform, overlay.clone())
+        }
+        // neither provided so get first device to and use its platform as platform and its name as
+        // overlay_handle
+        (None, None) => {
+            // this saves making two dbus calls by getting it all from the hashmap
+            let platforms = call_get_platform_types().await?;
+            let platform = platforms
+                .values()
+                .next()
+                .unwrap_or(&"universal".to_string())
+                .clone();
+            let overlay = platforms
+                .keys()
+                .next()
+                .unwrap_or(&"overlay0".to_string())
+                .clone();
+            (platform, overlay)
+        }
+    };
+
+    call_apply_overlay(&platform, file_path, &overlay_handle_to_use).await
+}
+
+/// Populates the device_handle appropriately before calling `call_load_bitstream`
+async fn load_bitstream(
+    device_handle: &Option<String>,
+    file_path: &str,
+) -> Result<String, zbus::Error> {
+    let dev = match device_handle {
+        None => get_first_device_handle().await?,
+        Some(dev) => dev.clone(),
+    };
+    call_load_bitstream("", &dev, file_path).await
+}
+
+/// Argument parser for the load command
+pub async fn load_handler(
+    dev_handle: &Option<String>,
+    sub_command: &LoadSubcommand,
+) -> Result<String, zbus::Error> {
+    match sub_command {
+        LoadSubcommand::Overlay { file, handle } => {
+            apply_overlay(dev_handle, file.as_ref(), handle).await
+        }
+        LoadSubcommand::Bitstream { file } => load_bitstream(dev_handle, file.as_ref()).await,
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,11 @@
 mod proxies;
 
+mod status;
+
 use clap::{Parser, Subcommand, arg, command};
-use log::debug;
+use log::{debug, error};
+use status::status_handler;
+use std::error::Error;
 
 #[derive(Parser, Debug)]
 #[command(name = "fpga")]
@@ -65,15 +69,24 @@ enum Commands {
     },
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
     let cli = Cli::parse();
     debug!("parsed cli command with {cli:?}");
-    match cli.command {
-        Commands::Status => {
-            todo!()
-        }
+    let result = match cli.command {
+        Commands::Status => status_handler(&cli.handle).await,
         Commands::Load { .. } => todo!(),
         Commands::Remove { .. } => todo!(),
+    };
+    match result {
+        Ok(msg) => {
+            println!("{msg}");
+            Ok(())
+        }
+        Err(e) => {
+            error!("{e}");
+            Err(e.into())
+        }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,5 @@
+mod proxies;
+
 use clap::{Parser, Subcommand, arg, command};
 use log::debug;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,10 @@ mod status;
 
 mod load;
 
+mod remove;
+
 use crate::load::load_handler;
+use crate::remove::remove_handler;
 use crate::status::status_handler;
 use clap::{Parser, Subcommand, arg, command};
 use log::{debug, error};
@@ -50,7 +53,7 @@ enum RemoveSubcommand {
         /// it is different than device_handle which is being used for platform
         /// detection logic.
         #[arg(long = "handle")]
-        handle: String,
+        handle: Option<String>,
     },
     /// Remove bitstream loaded in given `HANDLE` to fpga command
     Bitstream,
@@ -80,7 +83,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let result = match cli.command {
         Commands::Status => status_handler(&cli.handle).await,
         Commands::Load { command } => load_handler(&cli.handle, &command).await,
-        Commands::Remove { .. } => todo!(),
+        Commands::Remove { command } => remove_handler(&cli.handle, &command).await,
     };
     match result {
         Ok(msg) => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,9 +2,12 @@ mod proxies;
 
 mod status;
 
+mod load;
+
+use crate::load::load_handler;
+use crate::status::status_handler;
 use clap::{Parser, Subcommand, arg, command};
 use log::{debug, error};
-use status::status_handler;
 use std::error::Error;
 
 #[derive(Parser, Debug)]
@@ -76,7 +79,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     debug!("parsed cli command with {cli:?}");
     let result = match cli.command {
         Commands::Status => status_handler(&cli.handle).await,
-        Commands::Load { .. } => todo!(),
+        Commands::Load { command } => load_handler(&cli.handle, &command).await,
         Commands::Remove { .. } => todo!(),
     };
     match result {

--- a/cli/src/proxies/configure_proxy.rs
+++ b/cli/src/proxies/configure_proxy.rs
@@ -1,0 +1,14 @@
+use zbus::{Result, proxy};
+#[proxy(
+    default_service = "com.canonical.fpgad",
+    interface = "com.canonical.fpgad.configure",
+    default_path = "/com/canonical/fpgad/configure"
+)]
+pub trait Configure {
+    async fn get_overlay_control_dir(&self) -> Result<String>;
+    async fn get_firmware_source_dir(&self) -> Result<String>;
+    async fn get_fpga_managers_dir(&self) -> Result<String>;
+    async fn set_overlay_control_dir(&self, new_path: &str) -> Result<String>;
+    async fn set_firmware_source_dir(&self, new_path: &str) -> Result<String>;
+    async fn set_fpga_managers_dir(&self, new_path: &str) -> Result<String>;
+}

--- a/cli/src/proxies/control_proxy.rs
+++ b/cli/src/proxies/control_proxy.rs
@@ -1,0 +1,25 @@
+use zbus::{Result, proxy};
+#[proxy(
+    default_service = "com.canonical.fpgad",
+    interface = "com.canonical.fpgad.control",
+    default_path = "/com/canonical/fpgad/control"
+)]
+pub trait Control {
+    async fn load_defaults(&self) -> Result<String>;
+    async fn set_fpga_flags(&self, device_handle: &str, flags: u32) -> Result<String>;
+    async fn write_bitstream_direct(
+        &self,
+        platform_str: &str,
+        device_handle: &str,
+        bitstream_path_str: &str,
+    ) -> Result<String>;
+
+    async fn apply_overlay(
+        &self,
+        platform_str: &str,
+        overlay_handle: &str,
+        overlay_source_path: &str,
+    ) -> Result<String>;
+
+    async fn remove_overlay(&self, platform_str: &str, overlay_handle: &str) -> Result<String>;
+}

--- a/cli/src/proxies/mod.rs
+++ b/cli/src/proxies/mod.rs
@@ -1,0 +1,3 @@
+pub mod configure_proxy;
+pub mod control_proxy;
+pub mod status_proxy;

--- a/cli/src/proxies/status_proxy.rs
+++ b/cli/src/proxies/status_proxy.rs
@@ -1,0 +1,19 @@
+use zbus::{Result, proxy};
+#[proxy(
+    default_service = "com.canonical.fpgad",
+    interface = "com.canonical.fpgad.status",
+    default_path = "/com/canonical/fpgad/status"
+)]
+pub trait Status {
+    async fn get_fpga_state(&self, platform_string: &str, device_handle: &str) -> Result<String>;
+    async fn get_fpga_flags(&self, platform_string: &str, device_handle: &str) -> Result<String>;
+    async fn get_overlay_status(
+        &self,
+        platform_compat_str: &str,
+        overlay_handle: &str,
+    ) -> Result<String>;
+    async fn get_overlays(&self) -> Result<String>;
+    async fn get_platform_type(&self, device_handle: &str) -> Result<String>;
+    async fn get_platform_types(&self) -> Result<String>;
+    async fn get_platform_name(&self, _device_handle: &str) -> Result<String>;
+}

--- a/cli/src/remove.rs
+++ b/cli/src/remove.rs
@@ -1,0 +1,47 @@
+use crate::RemoveSubcommand;
+use crate::proxies::control_proxy;
+use crate::status::{call_get_platform_type, get_first_overlay, get_first_platform};
+use zbus::Connection;
+
+async fn remove_bitstream() -> Result<String, zbus::Error> {
+    // TODO: so this is confusing because we don't have a way to remove a bitstream but with
+    //  softeners we might end up with this functionality.
+    Err(zbus::Error::Failure("Not implemented".to_string()))
+}
+
+/// Sends the dbus command to remove an overlay
+async fn call_remove_overlay(
+    device_handle: &str,
+    overlay_handle: &str,
+) -> Result<String, zbus::Error> {
+    let connection = Connection::system().await?;
+    let proxy = control_proxy::ControlProxy::new(&connection).await?;
+    proxy.remove_overlay(device_handle, overlay_handle).await
+}
+
+/// Populates the platform and overlay handle appropriately before calling `call_apply_overlay`
+async fn remove_overlay(
+    device_handle: &Option<String>,
+    overlay_handle: &Option<String>,
+) -> Result<String, zbus::Error> {
+    let dev = match device_handle {
+        None => get_first_platform().await?,
+        Some(dev) => call_get_platform_type(dev).await?,
+    };
+    let handle = match overlay_handle {
+        Some(handle) => handle.clone(),
+        None => get_first_overlay().await?,
+    };
+    call_remove_overlay(&dev, &handle).await
+}
+
+/// Argument parser for the remove command
+pub async fn remove_handler(
+    dev_handle: &Option<String>,
+    sub_command: &RemoveSubcommand,
+) -> Result<String, zbus::Error> {
+    match sub_command {
+        RemoveSubcommand::Overlay { handle } => remove_overlay(dev_handle, handle).await,
+        RemoveSubcommand::Bitstream => remove_bitstream().await,
+    }
+}

--- a/cli/src/status.rs
+++ b/cli/src/status.rs
@@ -1,0 +1,128 @@
+use crate::proxies::status_proxy;
+use std::collections::HashMap;
+use zbus::Connection;
+
+/// Sends the dbus command to get a list of overlays and parses it
+pub async fn call_get_overlays() -> Result<Vec<String>, zbus::Error> {
+    let connection = Connection::system().await?;
+    let proxy = status_proxy::StatusProxy::new(&connection).await?;
+    let list_str = proxy.get_overlays().await?;
+    let ret_list: Vec<String> = list_str.lines().map(|line| line.to_string()).collect();
+    Ok(ret_list)
+}
+
+/// Sends the dbus command to get the state from an fpga device
+pub async fn call_get_fpga_state(device_handle: &str) -> Result<String, zbus::Error> {
+    let connection = Connection::system().await?;
+    let proxy = status_proxy::StatusProxy::new(&connection).await?;
+    proxy.get_fpga_state("", device_handle).await
+}
+
+/// Sends the dbus command to get the platform_compat_string for a given device
+pub async fn call_get_platform_type(device_handle: &str) -> Result<String, zbus::Error> {
+    let connection = Connection::system().await?;
+    let proxy = status_proxy::StatusProxy::new(&connection).await?;
+    proxy.get_platform_type(device_handle).await
+}
+
+/// Sends the dbus command to get the status string for a given overlay
+async fn call_get_overlay_status(
+    platform: &str,
+    overlay_handle: &str,
+) -> Result<String, zbus::Error> {
+    let connection = Connection::system().await?;
+    let proxy = status_proxy::StatusProxy::new(&connection).await?;
+    proxy.get_overlay_status(platform, overlay_handle).await
+}
+
+/// parses the string from `get_platform_types` interface into a HashMap of
+/// device: platform_compat_string
+pub async fn call_get_platform_types() -> Result<HashMap<String, String>, zbus::Error> {
+    let connection = Connection::system().await?;
+    let proxy = status_proxy::StatusProxy::new(&connection).await?;
+    let ret_str = proxy.get_platform_types().await?;
+    let ret_map = ret_str
+        .lines() // split by '\n'
+        .filter_map(|line| {
+            let mut parts = line.splitn(2, ':');
+            match (parts.next(), parts.next()) {
+                (Some(key), Some(value)) => Some((key.to_string(), value.to_string())),
+                _ => None, // ignore lines without a colon
+            }
+        })
+        .collect();
+    Ok(ret_map)
+}
+
+/// gets the first platform in the container from `call_get_platform_types`
+pub async fn get_first_platform() -> Result<String, zbus::Error> {
+    let platforms = call_get_platform_types().await?;
+    Ok(platforms
+        .values()
+        .next()
+        .unwrap_or(&"universal".to_string())
+        .clone())
+}
+
+/// gets the first overlay in the Vec from `call_get_overlays`
+pub async fn get_first_overlay() -> Result<String, zbus::Error> {
+    let overlays = call_get_overlays().await?;
+    let first = overlays.first().ok_or(zbus::Error::Failure(
+        "Could not find an overlay to remove".to_string(),
+    ))?;
+    Ok(first.clone())
+}
+
+/// gets the first platform in the container from `call_get_platform_types`
+pub async fn get_first_device_handle() -> Result<String, zbus::Error> {
+    let platform = match call_get_platform_types().await?.keys().next() {
+        Some(p) => p.clone(),
+        None => return Err(zbus::Error::Failure("Got no platforms.".to_string())),
+    };
+
+    Ok(platform)
+}
+
+/// gets one fpga state and returns an ascii table as String
+async fn get_fpga_state_message(device_handle: &str) -> Result<String, zbus::Error> {
+    let state = call_get_fpga_state(device_handle).await?;
+    let platform = call_get_platform_type(device_handle).await?;
+    Ok(format!(
+        "---- DEVICE  ----\n\
+        | dev | platform | state |\n\
+        {device_handle} | {platform} | {state}"
+    ))
+}
+
+/// get all fpga states, gets all overlay statuses, returns a ascii table as String
+async fn get_full_status_message() -> Result<String, zbus::Error> {
+    let mut ret_string = String::from(
+        "---- DEVICES ----\n\
+    | dev | platform | state |\n",
+    );
+
+    for (dev, platform) in call_get_platform_types().await? {
+        let state = call_get_fpga_state(&dev).await?;
+        ret_string += format!("| {dev} | {platform} | {state} |\n").as_str();
+    }
+    ret_string += "\n---- OVERLAYS ----\n\
+                   | overlay | status |\n";
+    for overlay in call_get_overlays().await? {
+        // TODO: overlays do not provide enough information to work out what platform to use.
+        //  so maybe the status command can take a platform type instead or something.
+        //  This is tricky.
+        let p = get_first_platform().await?;
+        let status = call_get_overlay_status(&p, &overlay).await?;
+        ret_string.push_str(format!("| {overlay} | {status} |\n").as_ref());
+    }
+    Ok(ret_string)
+}
+
+/// Argument parser for the status command
+pub async fn status_handler(device_handle: &Option<String>) -> Result<String, zbus::Error> {
+    let ret_string = match device_handle {
+        None => get_full_status_message().await?,
+        Some(dev) => get_fpga_state_message(dev.as_str()).await?,
+    };
+    Ok(ret_string)
+}

--- a/data/systemd/fpgad.service
+++ b/data/systemd/fpgad.service
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# FPGAd provides a strictly confined snap to which user bitstreams snaps can connect.
+# This connections provides a security hardened gateway necessary to load and unload
+# bitstreams to and from devices on Ubuntu core, and is a useful snap interface for
+# classic ubuntu.
+
+[Unit]
+Description=fpgad - FPGA daemon
+Documentation=https://github.com/canonical/fpgad
+
+[Service]
+Type=dbus
+BusName=com.canonical.fpgad
+Environment=RUST_LOG=info
+Environment=RUST_BACKTRACE=1
+ExecStart=/usr/bin/fpgad # change this to point to install loc
+User=root
+Restart=on-failure
+TimeoutStartSec=30
+StandardOutput=journal
+StandardError=journal
+StandardInput=null
+
+[Install]
+WantedBy=multi-user.target

--- a/src/comm/dbus/configure_interface.rs
+++ b/src/comm/dbus/configure_interface.rs
@@ -1,0 +1,53 @@
+use crate::config;
+use crate::error::FpgadError;
+use crate::system_io::{fs_read, fs_write};
+use log::trace;
+use std::path::Path;
+use zbus::{fdo, interface};
+
+pub struct ConfigureInterface {}
+
+fn write_firmware_source_dir(new_path: &str) -> Result<(), FpgadError> {
+    trace!(
+        "Writing fw prefix {} to {}",
+        new_path,
+        config::FIRMWARE_LOC_CONTROL_PATH
+    );
+    let fw_lookup_override = Path::new(config::FIRMWARE_LOC_CONTROL_PATH);
+    fs_write(fw_lookup_override, false, new_path)
+}
+
+fn read_firmware_source_dir() -> Result<String, FpgadError> {
+    trace!(
+        "Reading fw prefix from {}",
+        config::FIRMWARE_LOC_CONTROL_PATH
+    );
+    let fw_lookup_override = Path::new(config::FIRMWARE_LOC_CONTROL_PATH);
+    fs_read(fw_lookup_override)
+}
+
+pub fn set_firmware_source_dir(new_path: &str) -> Result<(), FpgadError> {
+    // TODO: checks for exist?
+    write_firmware_source_dir(new_path)
+}
+#[interface(name = "com.canonical.fpgad.configure")]
+impl ConfigureInterface {
+    async fn get_overlay_control_dir(&self) -> Result<String, fdo::Error> {
+        trace!("get_overlay_control_dir called");
+        Ok(config::OVERLAY_CONTROL_DIR.to_string())
+    }
+    async fn get_firmware_source_dir(&self) -> Result<String, fdo::Error> {
+        trace!("get_firmware_source_dir called");
+        Ok(read_firmware_source_dir()?)
+    }
+    async fn get_fpga_managers_dir(&self) -> Result<String, fdo::Error> {
+        trace!("get_fpga_managers_dir called");
+        Ok(config::FPGA_MANAGERS_DIR.to_string())
+    }
+
+    async fn set_firmware_source_dir(&self, new_path: &str) -> Result<String, fdo::Error> {
+        trace!("set_firmware_source_dir called with prefix: {new_path}");
+        set_firmware_source_dir(new_path)?;
+        Ok(format!("firmware_source_dir set to {new_path}"))
+    }
+}

--- a/src/comm/dbus/control_interface.rs
+++ b/src/comm/dbus/control_interface.rs
@@ -11,11 +11,7 @@ pub struct ControlInterface {}
 
 #[interface(name = "com.canonical.fpgad.control")]
 impl ControlInterface {
-    async fn set_fpga_flags(
-        &self,
-        device_handle: &str,
-        flags: isize,
-    ) -> Result<String, fdo::Error> {
+    async fn set_fpga_flags(&self, device_handle: &str, flags: u32) -> Result<String, fdo::Error> {
         trace!(
             "set_fpga_flags called with name: {} and flags: {}",
             device_handle, flags

--- a/src/comm/dbus/control_interface.rs
+++ b/src/comm/dbus/control_interface.rs
@@ -1,30 +1,31 @@
-use crate::platforms::platform::Fpga;
-use crate::platforms::platform::OverlayHandler;
-use crate::platforms::platform::Platform;
-use crate::platforms::platform::new_platform;
+use crate::platforms::platform::{platform_for_device, platform_for_known_platform};
 use crate::system_io::validate_device_handle;
 use log::trace;
 use std::path::Path;
 use zbus::{fdo, interface};
 
 pub struct ControlInterface {}
-
 #[interface(name = "com.canonical.fpgad.control")]
 impl ControlInterface {
-    async fn set_fpga_flags(&self, device_handle: &str, flags: u32) -> Result<String, fdo::Error> {
-        trace!(
-            "set_fpga_flags called with name: {} and flags: {}",
-            device_handle, flags
-        );
+    async fn set_fpga_flags(
+        &self,
+        platform_string: &str,
+        device_handle: &str,
+        flags: u32,
+    ) -> Result<String, fdo::Error> {
+        trace!("set_fpga_flags called with name: {device_handle} and flags: {flags}");
         validate_device_handle(device_handle)?;
-        new_platform(device_handle)
-            .fpga(device_handle)?
-            .set_flags(flags)?;
-        Ok(format!("Flags set to {} for {}", flags, device_handle))
+        let platform = match platform_string.is_empty() {
+            true => platform_for_device(device_handle)?,
+            false => platform_for_known_platform(platform_string)?,
+        };
+        platform.fpga(device_handle)?.set_flags(flags)?;
+        Ok(format!("Flags set to {flags} for {device_handle}"))
     }
 
     async fn write_bitstream_direct(
         &self,
+        platform_string: &str,
         device_handle: &str,
         bitstream_path_str: &str,
     ) -> Result<String, fdo::Error> {
@@ -35,29 +36,28 @@ impl ControlInterface {
         let path = Path::new(bitstream_path_str);
         if !path.exists() || path.is_dir() {
             return Err(fdo::Error::InvalidArgs(format!(
-                "{} is not a valid path to a bitstream file.",
-                bitstream_path_str
+                "{bitstream_path_str} is not a valid path to a bitstream file."
             )));
         }
-        new_platform(device_handle)
-            .fpga(device_handle)?
-            .load_firmware(path)?;
+        let platform = match platform_string.is_empty() {
+            true => platform_for_device(device_handle)?,
+            false => platform_for_known_platform(platform_string)?,
+        };
+        platform.fpga(device_handle)?.load_firmware(path)?;
         Ok(format!("{bitstream_path_str} loaded to {device_handle}"))
     }
 
     async fn apply_overlay(
         &self,
-        device_handle: &str,
+        platform_compat_str: &str,
         overlay_handle: &str,
         overlay_source_path: &str,
     ) -> Result<String, fdo::Error> {
         trace!(
-            "apply_overlay called with device_handle:{device_handle}, overlay_handle: \
+            "apply_overlay called with platform_compat_str:{platform_compat_str}, overlay_handle: \
             {overlay_handle} and overlay_path: {overlay_source_path}",
         );
-        validate_device_handle(device_handle)?;
-
-        let platform = new_platform(device_handle);
+        let platform = platform_for_known_platform(platform_compat_str)?;
         let overlay_handler = platform.overlay_handler(overlay_handle)?;
         let overlay_fs_path = overlay_handler.overlay_fs_path()?;
         overlay_handler.apply_overlay(Path::new(overlay_source_path))?;
@@ -68,15 +68,14 @@ impl ControlInterface {
 
     async fn remove_overlay(
         &self,
-        device_handle: &str,
+        platform_compat_str: &str,
         overlay_handle: &str,
     ) -> Result<String, fdo::Error> {
         trace!(
-            "remove_overlay called with device_handle: {device_handle} and overlay_handle:\
+            "remove_overlay called with platform_compat_str: {platform_compat_str} and overlay_handle:\
              {overlay_handle}"
         );
-        validate_device_handle(device_handle)?;
-        let platform = new_platform(device_handle);
+        let platform = platform_for_known_platform(platform_compat_str)?;
         let overlay_handler = platform.overlay_handler(overlay_handle)?;
         let overlay_fs_path = overlay_handler.overlay_fs_path()?;
         overlay_handler.remove_overlay()?;

--- a/src/comm/dbus/mod.rs
+++ b/src/comm/dbus/mod.rs
@@ -10,5 +10,6 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
+pub mod configure_interface;
 pub mod control_interface;
 pub mod status_interface;

--- a/src/comm/dbus/status_interface.rs
+++ b/src/comm/dbus/status_interface.rs
@@ -1,25 +1,40 @@
-use crate::platforms::platform::Fpga;
-use crate::platforms::platform::OverlayHandler;
-use crate::platforms::platform::Platform;
-use crate::platforms::platform::new_platform;
-use crate::system_io::validate_device_handle;
-use log::trace;
+use crate::config;
+use crate::platforms::platform::platform_for_known_platform;
+use crate::platforms::platform::{list_fpga_managers, platform_for_device, read_compatible_string};
+use crate::system_io::{fs_read_dir, validate_device_handle};
+use log::{error, trace};
 use zbus::{fdo, interface};
 
 pub struct StatusInterface {}
 
 #[interface(name = "com.canonical.fpgad.status")]
 impl StatusInterface {
-    async fn get_fpga_state(&self, device_handle: &str) -> Result<String, fdo::Error> {
-        trace!("get_fpga_state called with name: {}", device_handle);
+    async fn get_fpga_state(
+        &self,
+        platform_string: &str,
+        device_handle: &str,
+    ) -> Result<String, fdo::Error> {
+        trace!("get_fpga_state called with name: {device_handle}");
         validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle).fpga(device_handle)?.state()?)
+        let platform = match platform_string.is_empty() {
+            true => platform_for_device(device_handle)?,
+            false => platform_for_known_platform(platform_string)?,
+        };
+        Ok(platform.fpga(device_handle)?.state()?)
     }
 
-    async fn get_fpga_flags(&self, device_handle: &str) -> Result<String, fdo::Error> {
-        trace!("get_fpga_flags called with name: {}", device_handle);
+    async fn get_fpga_flags(
+        &self,
+        platform_string: &str,
+        device_handle: &str,
+    ) -> Result<String, fdo::Error> {
+        trace!("get_fpga_flags called with name: {device_handle}");
         validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle)
+        let platform = match platform_string.is_empty() {
+            true => platform_for_device(device_handle)?,
+            false => platform_for_known_platform(platform_string)?,
+        };
+        Ok(platform
             .fpga(device_handle)?
             .flags()
             .map(|flags| flags.to_string())?)
@@ -27,16 +42,47 @@ impl StatusInterface {
 
     async fn get_overlay_status(
         &self,
-        device_handle: &str,
+        platform_compat_str: &str,
         overlay_handle: &str,
     ) -> Result<String, fdo::Error> {
         trace!(
-            "get_overlay_status called with device_handle: {device_handle} and overlay_handle:\
+            "get_overlay_status called with platform_compat_str: {platform_compat_str} and overlay_handle:\
              {overlay_handle}"
         );
-        validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle)
+        Ok(platform_for_known_platform(platform_compat_str)?
             .overlay_handler(overlay_handle)?
             .status()?)
+    }
+
+    async fn get_overlays(&self) -> Result<String, fdo::Error> {
+        trace!("get_overlays called");
+        let overlay_handles = fs_read_dir(config::OVERLAY_CONTROL_DIR.as_ref())?;
+        Ok(overlay_handles.join("\n"))
+    }
+
+    async fn get_platform_type(&self, device_handle: &str) -> Result<String, fdo::Error> {
+        trace!("get_platform_type called with device_handle: {device_handle}");
+        validate_device_handle(device_handle)?;
+        let ret_string = read_compatible_string(device_handle)?;
+        Ok(ret_string.to_string())
+    }
+
+    async fn get_platform_types(&self) -> Result<String, fdo::Error> {
+        trace!("get_platform_types called");
+        let mut ret_string = String::new();
+        let devices = list_fpga_managers()?;
+        for device_handle in devices {
+            if let Ok(compat_string) = read_compatible_string(&device_handle) {
+                ret_string += format!("{device_handle}:{compat_string}\n").as_str();
+            } else {
+                error!("Failed to get string for {device_handle}");
+                ret_string += format!("{device_handle}:\n").as_str();
+            }
+        }
+        Ok(ret_string)
+    }
+
+    async fn get_platform_name(&self, _device_handle: &str) -> Result<String, fdo::Error> {
+        todo!()
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 // TODO: this should be provided by the config
-pub static FW_PREFIX: &str = "/lib/firmware/";
-pub static SYSFS_PREFIX: &str = "/sys/class/fpga_manager/";
-pub static CONFIGFS_PREFIX: &str = "/sys/kernel/config/device-tree/overlays/";
+pub static FIRMWARE_SOURCE_DIR: &str = "/lib/firmware/";
+pub static FPGA_MANAGERS_DIR: &str = "/sys/class/fpga_manager/";
+pub static OVERLAY_CONTROL_DIR: &str = "/sys/kernel/config/device-tree/overlays/";
+pub static FIRMWARE_LOC_CONTROL_PATH: &str = "/sys/module/firmware_class/parameters/path";

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -73,9 +73,9 @@ pub trait Fpga {
     /// get the state of the fpga device
     fn state(&self) -> Result<String, FpgadError>;
     /// get the current flags of the fpga device
-    fn flags(&self) -> Result<isize, FpgadError>;
+    fn flags(&self) -> Result<u32, FpgadError>;
     /// attempt to set the flags of an fpga device
-    fn set_flags(&self, flags: isize) -> Result<(), FpgadError>;
+    fn set_flags(&self, flags: u32) -> Result<(), FpgadError>;
     #[allow(dead_code)]
     /// Directly load the firmware stored in bitstream_path to the device
     fn load_firmware(&self, bitstream_path: &Path) -> Result<(), FpgadError>;

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -13,7 +13,7 @@
 use crate::config;
 use crate::error::FpgadError;
 use crate::platforms::universal::UniversalPlatform;
-use crate::system_io::fs_read;
+use crate::system_io::{fs_read, fs_read_dir};
 use log::{error, info, trace, warn};
 use std::path::Path;
 
@@ -21,25 +21,29 @@ use std::path::Path;
 enum PlatformType {
     Universal,
     ZynqMP,
+    Zynq, // no mp
     Versal,
 }
 
+//  TODO: this may become generic `xilinx,` for all xilinx devices instead, depending on what
+//   the softener code ends up looking like.
 const PLATFORM_SUBSTRINGS: &[(&str, PlatformType)] = &[
-    ("zynqmp", PlatformType::ZynqMP),
-    ("versal", PlatformType::Versal),
+    ("universal", PlatformType::Universal),
+    ("zynqmp-", PlatformType::ZynqMP),
+    ("versal-", PlatformType::Versal),
+    ("zynq-", PlatformType::Zynq),
 ];
 
 /// Scans /sys/class/fpga_manager/ for all present device nodes and returns a Vec of their handles
 #[allow(dead_code)]
-pub fn list_fpga_managers() -> Vec<String> {
-    std::fs::read_dir(config::FPGA_MANAGERS_DIR)
-        .map(|iter| {
-            iter.filter_map(Result::ok)
-                .map(|entry| entry.file_name().to_string_lossy().into_owned())
-                .collect()
-        })
-        .unwrap_or_default()
+pub fn list_fpga_managers() -> Result<Vec<String>, FpgadError> {
+    let prefix = config::FPGA_MANAGERS_DIR;
+    if prefix.is_empty() {
+        return Ok(vec!["".to_string()]);
+    };
+    fs_read_dir(prefix.as_ref())
 }
+
 
 /// A sysfs map of an fpga in fpga_manager class.
 /// See the example below (not all sysfs files are implemented as methods):
@@ -95,7 +99,19 @@ pub trait OverlayHandler {
     fn overlay_fs_path(&self) -> Result<&Path, FpgadError>;
 }
 
-fn discover_platform_type(device_handle: &str) -> PlatformType {
+fn match_platform_string(platform_string: &str) -> Result<PlatformType, FpgadError> {
+    for (substr, platform) in PLATFORM_SUBSTRINGS {
+        if platform_string.contains(substr) {
+            trace!("Found '{substr}'");
+            return Ok(*platform);
+        }
+    }
+    Err(FpgadError::Argument(format!(
+        "FPGAd could not match {platform_string} to a known platform."
+    )))
+}
+
+pub fn read_compatible_string(device_handle: &str) -> Result<String, FpgadError> {
     let compat_string = match fs_read(
         &Path::new(config::FPGA_MANAGERS_DIR)
             .join(device_handle)
@@ -103,53 +119,64 @@ fn discover_platform_type(device_handle: &str) -> PlatformType {
     ) {
         Err(e) => {
             error!(
-                "Failed to read platform from {:?}: {}\n\
+                "Failed to read platform from {device_handle:?}: {e}\n\
                 Universal will be used as platform type.",
-                device_handle, e
             );
-            return PlatformType::Universal;
+            return Ok("universal".to_string());
         }
-        Ok(s) => s,
+        Ok(s) => {
+            trace!("{s}");
+            // often driver virtual files contain null terminated strings instead of EOF terminated.
+            s.trim_end_matches('\0').to_string()
+        }
     };
-    trace!("Found compatibility string: '{}'", compat_string);
-
-    for (substr, platform) in PLATFORM_SUBSTRINGS {
-        if compat_string.contains(substr) {
-            trace!("Found '{substr}'");
-            return *platform;
-        }
-    }
-
-    warn!(
-        "FPGAd could not match {compat_string} for {device_handle} to a known platform.\
-    Using 'Universal'"
-    );
-    PlatformType::Universal
+    Ok(compat_string)
 }
 
-pub fn new_platform(device_handle: &str) -> impl Platform {
-    let platform_name = discover_platform_type(device_handle);
-    match platform_name {
+fn discover_platform_type(device_handle: &str) -> Result<PlatformType, FpgadError> {
+    let compat_string = read_compatible_string(device_handle)?;
+    trace!("Found compatibility string: '{compat_string}'");
+    Ok(match_platform_string(&compat_string).unwrap_or({
+        warn!("{compat_string} not supported. Defaulting to Universal platform.");
+        PlatformType::Universal
+    }))
+}
+
+fn new_platform(platform_type: PlatformType) -> Box<dyn Platform> {
+    match platform_type {
         PlatformType::Universal => {
             info!("Using platform: Universal");
-            UniversalPlatform::new()
+            Box::new(UniversalPlatform::new())
+        }
+        PlatformType::Zynq => {
+            warn!("Zynq not implemented yet: using Universal");
+            Box::new(UniversalPlatform::new())
         }
         PlatformType::ZynqMP => {
             warn!("ZynqMP not implemented yet: using Universal");
-            UniversalPlatform::new()
+            Box::new(UniversalPlatform::new())
         }
         PlatformType::Versal => {
             warn!("Versal not implemented yet: using Universal");
-            UniversalPlatform::new()
+            Box::new(UniversalPlatform::new())
         }
     }
 }
+
+pub fn platform_for_device(device_handle: &str) -> Result<Box<dyn Platform>, FpgadError> {
+    Ok(new_platform(discover_platform_type(device_handle)?))
+}
+
+pub fn platform_for_known_platform(platform_string: &str) -> Result<Box<dyn Platform>, FpgadError> {
+    Ok(new_platform(match_platform_string(platform_string)?))
+}
+
 pub trait Platform {
     #[allow(dead_code)]
     /// gets the name of the Platform type e.g. Universal or ZynqMP
     fn platform_type(&self) -> &str;
     /// creates and inits an Fpga if not present otherwise gets the instance
-    fn fpga(&self, device_handle: &str) -> Result<&impl Fpga, FpgadError>;
+    fn fpga(&self, device_handle: &str) -> Result<&dyn Fpga, FpgadError>;
     /// creates and inits an OverlayHandler if not present otherwise gets the instance
-    fn overlay_handler(&self, overlay_handle: &str) -> Result<&impl OverlayHandler, FpgadError>;
+    fn overlay_handler(&self, overlay_handle: &str) -> Result<&dyn OverlayHandler, FpgadError>;
 }

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -32,7 +32,7 @@ const PLATFORM_SUBSTRINGS: &[(&str, PlatformType)] = &[
 /// Scans /sys/class/fpga_manager/ for all present device nodes and returns a Vec of their handles
 #[allow(dead_code)]
 pub fn list_fpga_managers() -> Vec<String> {
-    std::fs::read_dir(config::SYSFS_PREFIX)
+    std::fs::read_dir(config::FPGA_MANAGERS_DIR)
         .map(|iter| {
             iter.filter_map(Result::ok)
                 .map(|entry| entry.file_name().to_string_lossy().into_owned())
@@ -97,7 +97,7 @@ pub trait OverlayHandler {
 
 fn discover_platform_type(device_handle: &str) -> PlatformType {
     let compat_string = match fs_read(
-        &Path::new(config::SYSFS_PREFIX)
+        &Path::new(config::FPGA_MANAGERS_DIR)
             .join(device_handle)
             .join("of_node/compatible"),
     ) {

--- a/src/platforms/universal.rs
+++ b/src/platforms/universal.rs
@@ -61,8 +61,7 @@ impl Platform for UniversalPlatform {
 
         if !parent_path.exists() {
             return Err(FpgadError::Argument(format!(
-                "The overlayfs path {:?} doesn't seem to exist.",
-                parent_path
+                "The overlayfs path {parent_path:?} doesn't seem to exist."
             )));
         }
         Ok(handler)

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -61,7 +61,7 @@ impl Fpga for UniversalFPGA {
     ///
     /// returns: Result<String, FpgadError>
     fn state(&self) -> Result<String, FpgadError> {
-        let state_path = Path::new(config::SYSFS_PREFIX)
+        let state_path = Path::new(config::FPGA_MANAGERS_DIR)
             .join(self.device_handle.clone())
             .join("state");
         trace!("reading {state_path:?}");
@@ -71,7 +71,7 @@ impl Fpga for UniversalFPGA {
     /// Gets the flags from the hex string stored in the sysfs flags file
     /// e.g. sys/class/fpga_manager/fpga0/flags
     fn flags(&self) -> Result<u32, FpgadError> {
-        let flag_path = Path::new(config::SYSFS_PREFIX)
+        let flag_path = Path::new(config::FPGA_MANAGERS_DIR)
             .join(self.device_handle.clone())
             .join("flags");
         let contents = fs_read(&flag_path)?;
@@ -83,7 +83,7 @@ impl Fpga for UniversalFPGA {
     /// Sets the flags in the sysfs flags file (e.g. sys/class/fpga_manager/fpga0/flags)
     /// and verifies the write command stuck by reading it back.
     fn set_flags(&self, flags: u32) -> Result<(), FpgadError> {
-        let flag_path = Path::new(config::SYSFS_PREFIX)
+        let flag_path = Path::new(config::FPGA_MANAGERS_DIR)
             .join(self.device_handle.clone())
             .join("flags");
         trace!("Writing '{flags}' to '{flag_path:?}");
@@ -127,12 +127,12 @@ impl Fpga for UniversalFPGA {
     /// Note: always load firmware before overlay.
     fn load_firmware(&self, bitstream_path: &Path) -> Result<(), FpgadError> {
         let stripped_path = bitstream_path
-            .strip_prefix(config::FW_PREFIX)
+            .strip_prefix(config::FIRMWARE_SOURCE_DIR)
             .map_err(|_| {
                 FpgadError::Argument(format!(
                     "Bitstream path {:?} is not under the configured firmware directory '{}'",
                     bitstream_path,
-                    config::FW_PREFIX
+                    config::FIRMWARE_SOURCE_DIR
                 ))
             })?;
 
@@ -142,7 +142,7 @@ impl Fpga for UniversalFPGA {
             ))
         })?;
 
-        let control_path = Path::new(config::SYSFS_PREFIX)
+        let control_path = Path::new(config::FPGA_MANAGERS_DIR)
             .join(self.device_handle())
             .join("firmware");
         fs_write(&control_path, false, relative_path)?;

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -70,19 +70,19 @@ impl Fpga for UniversalFPGA {
 
     /// Gets the flags from the hex string stored in the sysfs flags file
     /// e.g. sys/class/fpga_manager/fpga0/flags
-    fn flags(&self) -> Result<isize, FpgadError> {
+    fn flags(&self) -> Result<u32, FpgadError> {
         let flag_path = Path::new(config::SYSFS_PREFIX)
             .join(self.device_handle.clone())
             .join("flags");
         let contents = fs_read(&flag_path)?;
         let trimmed = contents.trim().trim_start_matches("0x");
-        isize::from_str_radix(trimmed, 16)
+        u32::from_str_radix(trimmed, 16)
             .map_err(|_| FpgadError::Flag("Parsing flags failed".into()))
     }
 
     /// Sets the flags in the sysfs flags file (e.g. sys/class/fpga_manager/fpga0/flags)
     /// and verifies the write command stuck by reading it back.
-    fn set_flags(&self, flags: isize) -> Result<(), FpgadError> {
+    fn set_flags(&self, flags: u32) -> Result<(), FpgadError> {
         let flag_path = Path::new(config::SYSFS_PREFIX)
             .join(self.device_handle.clone())
             .join("flags");
@@ -138,8 +138,7 @@ impl Fpga for UniversalFPGA {
 
         let relative_path = stripped_path.to_str().ok_or_else(|| {
             FpgadError::Argument(format!(
-                "Stripped bitstream path {:?} is not valid UTF-8",
-                stripped_path
+                "Stripped bitstream path {stripped_path:?} is not valid UTF-8"
             ))
         })?;
 

--- a/src/platforms/universal_components/universal_overlay_handler.rs
+++ b/src/platforms/universal_components/universal_overlay_handler.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 /// device, overlay or bitstream, and so the handle is specified by the user here and the rest
 /// is fixed.
 fn construct_overlay_fs_path(overlay_handle: &str) -> PathBuf {
-    let overlay_fs_path = PathBuf::from(config::CONFIGFS_PREFIX).join(overlay_handle);
+    let overlay_fs_path = PathBuf::from(config::OVERLAY_CONTROL_DIR).join(overlay_handle);
     trace!("overlay_fs_path will be {overlay_fs_path:?}");
     overlay_fs_path
 }

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -27,9 +27,11 @@ pub fn fs_read(file_path: &Path) -> Result<String, FpgadError> {
         .open(file_path)
         .and_then(|mut f| f.read_to_string(&mut buf));
 
-    // do checks on the data we got if necessary
     match result {
-        Ok(_) => Ok(buf),
+        Ok(_) => {
+            trace!("Reading done");
+            Ok(buf)
+        }
         Err(e) => Err(FpgadError::IORead {
             file: file_path.into(),
             e,
@@ -95,14 +97,6 @@ pub fn fs_remove_dir(path: &Path) -> Result<(), FpgadError> {
     }
 }
 
-/// Helper function to extract the filename from a path and wrap the errors
-pub fn extract_filename(path: &Path) -> Result<&str, FpgadError> {
-    path.file_name()
-        .ok_or_else(|| FpgadError::Internal(format!("No filename in path: {:?}", path)))?
-        .to_str()
-        .ok_or_else(|| FpgadError::Internal(format!("Filename not UTF-8: {:?}", path)))
-}
-
 /// Convenient wrapper for reading contents of a directory
 pub fn fs_read_dir(dir: &Path) -> Result<Vec<String>, FpgadError> {
     trace!("Attempting to read directory '{dir:?}'");
@@ -123,6 +117,15 @@ pub fn fs_read_dir(dir: &Path) -> Result<Vec<String>, FpgadError> {
         },
     )
 }
+
+/// Helper function to extract the filename from a path and wrap the errors
+pub fn extract_filename(path: &Path) -> Result<&str, FpgadError> {
+    path.file_name()
+        .ok_or_else(|| FpgadError::Internal(format!("No filename in path: {:?}", path)))?
+        .to_str()
+        .ok_or_else(|| FpgadError::Internal(format!("Filename not UTF-8: {:?}", path)))
+}
+
 
 /// Helper function to check that a device with given handle does exist.
 pub(crate) fn validate_device_handle(device_handle: &str) -> Result<(), FpgadError> {

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -132,7 +132,7 @@ pub(crate) fn validate_device_handle(device_handle: &str) -> Result<(), FpgadErr
                 fpga name must be compliant with sysfs rules."
         )));
     }
-    let fpga_managers_dir = config::SYSFS_PREFIX;
+    let fpga_managers_dir = config::FPGA_MANAGERS_DIR;
     if !PathBuf::from(fpga_managers_dir)
         .join(device_handle)
         .exists()


### PR DESCRIPTION
e.g.
```
$ sudo ./target/debug/fpga status
                   DEVICES                    
┌────────┬───────────────────────┬───────────┐
│ Handle │ Platform              │ State     │
├────────┼───────────────────────┼───────────┤
│ fpga0  │ xlnx,zynqmp-pcap-fpga │ operating │
└────────┴───────────────────────┴───────────┘

                   OVERLAYS                   
┌─────────┬──────────────────────────────────┐
│ Handle  │ Status                           │
├─────────┼──────────────────────────────────┤
│ fpga0   │ "k26-starter-kits.dtbo" applied  │
└─────────┴──────────────────────────────────┘

```