### PR TITLE
dbus: platforms: require platform string for calls not specifically requiring device

### DIFF
--- a/.git_components.yaml
+++ b/.git_components.yaml
@@ -30,3 +30,6 @@ cli:
 docs:
   owners:
     - artiepoole
+config:
+  owners:
+    - artiepoole

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +729,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
 name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,17 +808,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ members = ["cli"]
 [dependencies]
 log = "0.4.27"
 env_logger = "0.11.8"
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.46.0", features = ["full"] }
 zbus = { version = "5.5.0", default-features = false, features = ["tokio"] }
 thiserror = "2.0.12"

--- a/src/comm/dbus/control_interface.rs
+++ b/src/comm/dbus/control_interface.rs
@@ -28,15 +28,12 @@ impl ControlInterface {
         device_handle: &str,
         flags: isize,
     ) -> Result<String, fdo::Error> {
-        trace!(
-            "set_fpga_flags called with name: {} and flags: {}",
-            device_handle, flags
-        );
+        trace!("set_fpga_flags called with name: {device_handle} and flags: {flags}");
         validate_device_handle(device_handle)?;
         new_platform(device_handle)
             .fpga(device_handle)?
             .set_flags(flags)?;
-        Ok(format!("Flags set to {} for {}", flags, device_handle))
+        Ok(format!("Flags set to {flags} for {device_handle}"))
     }
 
     async fn write_bitstream_direct(
@@ -51,8 +48,7 @@ impl ControlInterface {
         let path = Path::new(bitstream_path_str);
         if !path.exists() || path.is_dir() {
             return Err(fdo::Error::InvalidArgs(format!(
-                "{} is not a valid path to a bitstream file.",
-                bitstream_path_str
+                "{bitstream_path_str} is not a valid path to a bitstream file."
             )));
         }
         new_platform(device_handle)

--- a/src/comm/dbus/control_interface.rs
+++ b/src/comm/dbus/control_interface.rs
@@ -23,11 +23,7 @@ pub struct ControlInterface {}
 
 #[interface(name = "com.canonical.fpgad.control")]
 impl ControlInterface {
-    async fn set_fpga_flags(
-        &self,
-        device_handle: &str,
-        flags: isize,
-    ) -> Result<String, fdo::Error> {
+    async fn set_fpga_flags(&self, device_handle: &str, flags: u32) -> Result<String, fdo::Error> {
         trace!("set_fpga_flags called with name: {device_handle} and flags: {flags}");
         validate_device_handle(device_handle)?;
         new_platform(device_handle)

--- a/src/comm/dbus/mod.rs
+++ b/src/comm/dbus/mod.rs
@@ -10,4 +10,5 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-pub mod interfaces;
+pub mod control_interface;
+pub mod status_interface;

--- a/src/comm/dbus/status_interface.rs
+++ b/src/comm/dbus/status_interface.rs
@@ -1,0 +1,54 @@
+// This file is part of fpgad, an application to manage FPGA subsystem together with device-tree and kernel modules.
+//
+// Copyright 2025 Canonical Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// fpgad is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 3, as published by the Free Software Foundation.
+//
+// fpgad is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranties of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
+
+use crate::platforms::platform::Fpga;
+use crate::platforms::platform::OverlayHandler;
+use crate::platforms::platform::Platform;
+use crate::platforms::platform::new_platform;
+use crate::system_io::validate_device_handle;
+use log::trace;
+use zbus::{fdo, interface};
+
+pub struct StatusInterface {}
+
+#[interface(name = "com.canonical.fpgad.status")]
+impl StatusInterface {
+    async fn get_fpga_state(&self, device_handle: &str) -> Result<String, fdo::Error> {
+        trace!("get_fpga_state called with name: {}", device_handle);
+        validate_device_handle(device_handle)?;
+        Ok(new_platform(device_handle).fpga(device_handle)?.state()?)
+    }
+
+    async fn get_fpga_flags(&self, device_handle: &str) -> Result<String, fdo::Error> {
+        trace!("get_fpga_flags called with name: {}", device_handle);
+        validate_device_handle(device_handle)?;
+        Ok(new_platform(device_handle)
+            .fpga(device_handle)?
+            .flags()
+            .map(|flags| flags.to_string())?)
+    }
+
+    async fn get_overlay_status(
+        &self,
+        device_handle: &str,
+        overlay_handle: &str,
+    ) -> Result<String, fdo::Error> {
+        trace!(
+            "get_overlay_status called with device_handle: {device_handle} and overlay_handle:\
+             {overlay_handle}"
+        );
+        validate_device_handle(device_handle)?;
+        Ok(new_platform(device_handle)
+            .overlay_handler(overlay_handle)?
+            .status()?)
+    }
+}

--- a/src/comm/dbus/status_interface.rs
+++ b/src/comm/dbus/status_interface.rs
@@ -10,28 +10,37 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-use crate::platforms::platform::Fpga;
-use crate::platforms::platform::OverlayHandler;
-use crate::platforms::platform::Platform;
-use crate::platforms::platform::new_platform;
-use crate::system_io::validate_device_handle;
-use log::trace;
+use crate::config;
+use crate::platforms::platform::{list_fpga_managers, read_compatible_string};
+use crate::platforms::platform::{platform_for_known_platform, platform_from_compat_or_device};
+use crate::system_io::{fs_read_dir, validate_device_handle};
+use log::{error, trace};
 use zbus::{fdo, interface};
 
 pub struct StatusInterface {}
 
 #[interface(name = "com.canonical.fpgad.status")]
 impl StatusInterface {
-    async fn get_fpga_state(&self, device_handle: &str) -> Result<String, fdo::Error> {
+    async fn get_fpga_state(
+        &self,
+        platform_string: &str,
+        device_handle: &str,
+    ) -> Result<String, fdo::Error> {
         trace!("get_fpga_state called with name: {device_handle}");
         validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle).fpga(device_handle)?.state()?)
+        let platform = platform_from_compat_or_device(platform_string, device_handle)?;
+        Ok(platform.fpga(device_handle)?.state()?)
     }
 
-    async fn get_fpga_flags(&self, device_handle: &str) -> Result<String, fdo::Error> {
+    async fn get_fpga_flags(
+        &self,
+        platform_string: &str,
+        device_handle: &str,
+    ) -> Result<String, fdo::Error> {
         trace!("get_fpga_flags called with name: {device_handle}");
         validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle)
+        let platform = platform_from_compat_or_device(platform_string, device_handle)?;
+        Ok(platform
             .fpga(device_handle)?
             .flags()
             .map(|flags| flags.to_string())?)
@@ -39,16 +48,47 @@ impl StatusInterface {
 
     async fn get_overlay_status(
         &self,
-        device_handle: &str,
+        platform_compat_str: &str,
         overlay_handle: &str,
     ) -> Result<String, fdo::Error> {
         trace!(
-            "get_overlay_status called with device_handle: {device_handle} and overlay_handle:\
+            "get_overlay_status called with platform_compat_str: {platform_compat_str} and overlay_handle:\
              {overlay_handle}"
         );
-        validate_device_handle(device_handle)?;
-        Ok(new_platform(device_handle)
+        Ok(platform_for_known_platform(platform_compat_str)?
             .overlay_handler(overlay_handle)?
             .status()?)
+    }
+
+    async fn get_overlays(&self) -> Result<String, fdo::Error> {
+        trace!("get_overlays called");
+        let overlay_handles = fs_read_dir(config::OVERLAY_CONTROL_DIR.as_ref())?;
+        Ok(overlay_handles.join("\n"))
+    }
+
+    async fn get_platform_type(&self, device_handle: &str) -> Result<String, fdo::Error> {
+        trace!("get_platform_type called with device_handle: {device_handle}");
+        validate_device_handle(device_handle)?;
+        let ret_string = read_compatible_string(device_handle)?;
+        Ok(ret_string.to_string())
+    }
+
+    async fn get_platform_types(&self) -> Result<String, fdo::Error> {
+        trace!("get_platform_types called");
+        let mut ret_string = String::new();
+        let devices = list_fpga_managers()?;
+        for device_handle in devices {
+            if let Ok(compat_string) = read_compatible_string(&device_handle) {
+                ret_string += format!("{device_handle}:{compat_string}\n").as_str();
+            } else {
+                error!("Failed to get string for {device_handle}");
+                ret_string += format!("{device_handle}:\n").as_str();
+            }
+        }
+        Ok(ret_string)
+    }
+
+    async fn get_platform_name(&self, _device_handle: &str) -> Result<String, fdo::Error> {
+        todo!()
     }
 }

--- a/src/comm/dbus/status_interface.rs
+++ b/src/comm/dbus/status_interface.rs
@@ -23,13 +23,13 @@ pub struct StatusInterface {}
 #[interface(name = "com.canonical.fpgad.status")]
 impl StatusInterface {
     async fn get_fpga_state(&self, device_handle: &str) -> Result<String, fdo::Error> {
-        trace!("get_fpga_state called with name: {}", device_handle);
+        trace!("get_fpga_state called with name: {device_handle}");
         validate_device_handle(device_handle)?;
         Ok(new_platform(device_handle).fpga(device_handle)?.state()?)
     }
 
     async fn get_fpga_flags(&self, device_handle: &str) -> Result<String, fdo::Error> {
-        trace!("get_fpga_flags called with name: {}", device_handle);
+        trace!("get_fpga_flags called with name: {device_handle}");
         validate_device_handle(device_handle)?;
         Ok(new_platform(device_handle)
             .fpga(device_handle)?

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,16 @@
-// TODO: this should be provided by the config
-pub static FW_PREFIX: &str = "/lib/firmware/";
-pub static SYSFS_PREFIX: &str = "/sys/class/fpga_manager/";
-pub static CONFIGFS_PREFIX: &str = "/sys/kernel/config/device-tree/overlays/";
+// This file is part of fpgad, an application to manage FPGA subsystem together with device-tree and kernel modules.
+//
+// Copyright 2025 Canonical Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// fpgad is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 3, as published by the Free Software Foundation.
+//
+// fpgad is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranties of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
+
+pub static FIRMWARE_SOURCE_DIR: &str = "/lib/firmware/";
+pub static FPGA_MANAGERS_DIR: &str = "/sys/class/fpga_manager/";
+pub static OVERLAY_CONTROL_DIR: &str = "/sys/kernel/config/device-tree/overlays/";
+pub static FIRMWARE_LOC_CONTROL_PATH: &str = "/sys/module/firmware_class/parameters/path";

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,8 @@ pub enum FpgadError {
     IOCreate { file: PathBuf, e: std::io::Error },
     #[error("FpgadError::IODelete: An IO error occurred when deleting {file:?}: {e}")]
     IODelete { file: PathBuf, e: std::io::Error },
+    #[error("FpgadError::IOReadDir: An IO error occurred when reading directory {dir:?}: {e}")]
+    IOReadDir { dir: PathBuf, e: std::io::Error },
     #[error("FpgadError::Internal: An Internal error occurred: {0}")]
     Internal(String),
 }
@@ -49,6 +51,7 @@ impl From<FpgadError> for fdo::Error {
             FpgadError::IOWrite { .. } => fdo::Error::IOError(err.to_string()),
             FpgadError::IOCreate { .. } => fdo::Error::IOError(err.to_string()),
             FpgadError::IODelete { .. } => fdo::Error::IOError(err.to_string()),
+            FpgadError::IOReadDir { .. } => fdo::Error::IOError(err.to_string()),
             _ => fdo::Error::Failed(err.to_string()),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,7 +42,7 @@ pub enum FpgadError {
 
 impl From<FpgadError> for fdo::Error {
     fn from(err: FpgadError) -> Self {
-        error!("{}", err);
+        error!("{err}");
         match err {
             FpgadError::Argument(..) => fdo::Error::InvalidArgs(err.to_string()),
             FpgadError::IORead { .. } => fdo::Error::IOError(err.to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod config;
 mod platforms;
 mod system_io;
 
-use crate::comm::dbus::interfaces::{ControlInterface, StatusInterface};
+use crate::comm::dbus::{control_interface::ControlInterface, status_interface::StatusInterface};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -73,9 +73,9 @@ pub trait Fpga {
     /// get the state of the fpga device
     fn state(&self) -> Result<String, FpgadError>;
     /// get the current flags of the fpga device
-    fn flags(&self) -> Result<isize, FpgadError>;
+    fn flags(&self) -> Result<u32, FpgadError>;
     /// attempt to set the flags of an fpga device
-    fn set_flags(&self, flags: isize) -> Result<(), FpgadError>;
+    fn set_flags(&self, flags: u32) -> Result<(), FpgadError>;
     #[allow(dead_code)]
     /// Directly load the firmware stored in bitstream_path to the device
     fn load_firmware(&self, bitstream_path: &Path) -> Result<(), FpgadError>;

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -103,15 +103,14 @@ fn discover_platform_type(device_handle: &str) -> PlatformType {
     ) {
         Err(e) => {
             error!(
-                "Failed to read platform from {:?}: {}\n\
-                Universal will be used as platform type.",
-                device_handle, e
+                "Failed to read platform from {device_handle:?}: {e}\n\
+                Universal will be used as platform type."
             );
             return PlatformType::Universal;
         }
         Ok(s) => s,
     };
-    trace!("Found compatibility string: '{}'", compat_string);
+    trace!("Found compatibility string: '{compat_string}'");
 
     for (substr, platform) in PLATFORM_SUBSTRINGS {
         if compat_string.contains(substr) {

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -13,7 +13,7 @@
 use crate::config;
 use crate::error::FpgadError;
 use crate::platforms::universal::UniversalPlatform;
-use crate::system_io::fs_read;
+use crate::system_io::{fs_read, fs_read_dir};
 use log::{error, info, trace, warn};
 use std::path::Path;
 
@@ -21,24 +21,23 @@ use std::path::Path;
 enum PlatformType {
     Universal,
     ZynqMP,
+    Zynq, // no mp
     Versal,
 }
 
+//  TODO: this may become generic `xilinx,` for all xilinx devices instead, depending on what
+//   the softener code ends up looking like.
 const PLATFORM_SUBSTRINGS: &[(&str, PlatformType)] = &[
-    ("zynqmp", PlatformType::ZynqMP),
-    ("versal", PlatformType::Versal),
+    ("universal", PlatformType::Universal),
+    ("zynqmp-", PlatformType::ZynqMP),
+    ("versal-", PlatformType::Versal),
+    ("zynq-", PlatformType::Zynq),
 ];
 
 /// Scans /sys/class/fpga_manager/ for all present device nodes and returns a Vec of their handles
 #[allow(dead_code)]
-pub fn list_fpga_managers() -> Vec<String> {
-    std::fs::read_dir(config::FPGA_MANAGERS_DIR)
-        .map(|iter| {
-            iter.filter_map(Result::ok)
-                .map(|entry| entry.file_name().to_string_lossy().into_owned())
-                .collect()
-        })
-        .unwrap_or_default()
+pub fn list_fpga_managers() -> Result<Vec<String>, FpgadError> {
+    fs_read_dir(config::FPGA_MANAGERS_DIR.as_ref())
 }
 
 /// A sysfs map of an fpga in fpga_manager class.
@@ -95,7 +94,19 @@ pub trait OverlayHandler {
     fn overlay_fs_path(&self) -> Result<&Path, FpgadError>;
 }
 
-fn discover_platform_type(device_handle: &str) -> PlatformType {
+fn match_platform_string(platform_string: &str) -> Result<PlatformType, FpgadError> {
+    for (substr, platform) in PLATFORM_SUBSTRINGS {
+        if platform_string.contains(substr) {
+            trace!("Found '{substr}'");
+            return Ok(*platform);
+        }
+    }
+    Err(FpgadError::Argument(format!(
+        "FPGAd could not match {platform_string} to a known platform."
+    )))
+}
+
+pub fn read_compatible_string(device_handle: &str) -> Result<String, FpgadError> {
     let compat_string = match fs_read(
         &Path::new(config::FPGA_MANAGERS_DIR)
             .join(device_handle)
@@ -104,51 +115,63 @@ fn discover_platform_type(device_handle: &str) -> PlatformType {
         Err(e) => {
             error!(
                 "Failed to read platform from {device_handle:?}: {e}\n\
-                Universal will be used as platform type."
+                Universal will be used as platform type.",
             );
-            return PlatformType::Universal;
+            return Ok("universal".to_string());
         }
-        Ok(s) => s,
+        Ok(s) => {
+            trace!("{s}");
+            // often driver virtual files contain null terminated strings instead of EOF terminated.
+            s.trim_end_matches('\0').to_string()
+        }
     };
-    trace!("Found compatibility string: '{compat_string}'");
-
-    for (substr, platform) in PLATFORM_SUBSTRINGS {
-        if compat_string.contains(substr) {
-            trace!("Found '{substr}'");
-            return *platform;
-        }
-    }
-
-    warn!(
-        "FPGAd could not match {compat_string} for {device_handle} to a known platform.\
-    Using 'Universal'"
-    );
-    PlatformType::Universal
+    Ok(compat_string)
 }
 
-pub fn new_platform(device_handle: &str) -> impl Platform {
-    let platform_name = discover_platform_type(device_handle);
-    match platform_name {
+fn discover_platform_type(device_handle: &str) -> Result<PlatformType, FpgadError> {
+    let compat_string = read_compatible_string(device_handle)?;
+    trace!("Found compatibility string: '{compat_string}'");
+    Ok(match_platform_string(&compat_string).unwrap_or_else(|_| {
+        warn!("{compat_string} not supported. Defaulting to Universal platform.");
+        PlatformType::Universal
+    }))
+}
+
+fn new_platform(platform_type: PlatformType) -> Box<dyn Platform> {
+    match platform_type {
         PlatformType::Universal => {
             info!("Using platform: Universal");
-            UniversalPlatform::new()
+            Box::new(UniversalPlatform::new())
         }
-        PlatformType::ZynqMP => {
-            warn!("ZynqMP not implemented yet: using Universal");
-            UniversalPlatform::new()
-        }
-        PlatformType::Versal => {
-            warn!("Versal not implemented yet: using Universal");
-            UniversalPlatform::new()
+        PlatformType::Xilinx => {
+            warn!("Xilinx not implemented yet: using Universal");
+            Box::new(UniversalPlatform::new())
         }
     }
 }
+pub fn platform_from_compat_or_device(
+    platform_string: &str,
+    device_handle: &str,
+) -> Result<Box<dyn Platform>, FpgadError> {
+    match platform_string.is_empty() {
+        true => platform_for_device(device_handle),
+        false => platform_for_known_platform(platform_string),
+    }
+}
+fn platform_for_device(device_handle: &str) -> Result<Box<dyn Platform>, FpgadError> {
+    Ok(new_platform(discover_platform_type(device_handle)?))
+}
+
+pub fn platform_for_known_platform(platform_string: &str) -> Result<Box<dyn Platform>, FpgadError> {
+    Ok(new_platform(match_platform_string(platform_string)?))
+}
+
 pub trait Platform {
     #[allow(dead_code)]
     /// gets the name of the Platform type e.g. Universal or ZynqMP
     fn platform_type(&self) -> &str;
     /// creates and inits an Fpga if not present otherwise gets the instance
-    fn fpga(&self, device_handle: &str) -> Result<&impl Fpga, FpgadError>;
+    fn fpga(&self, device_handle: &str) -> Result<&dyn Fpga, FpgadError>;
     /// creates and inits an OverlayHandler if not present otherwise gets the instance
-    fn overlay_handler(&self, overlay_handle: &str) -> Result<&impl OverlayHandler, FpgadError>;
+    fn overlay_handler(&self, overlay_handle: &str) -> Result<&dyn OverlayHandler, FpgadError>;
 }

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -32,7 +32,7 @@ const PLATFORM_SUBSTRINGS: &[(&str, PlatformType)] = &[
 /// Scans /sys/class/fpga_manager/ for all present device nodes and returns a Vec of their handles
 #[allow(dead_code)]
 pub fn list_fpga_managers() -> Vec<String> {
-    std::fs::read_dir(config::SYSFS_PREFIX)
+    std::fs::read_dir(config::FPGA_MANAGERS_DIR)
         .map(|iter| {
             iter.filter_map(Result::ok)
                 .map(|entry| entry.file_name().to_string_lossy().into_owned())
@@ -97,7 +97,7 @@ pub trait OverlayHandler {
 
 fn discover_platform_type(device_handle: &str) -> PlatformType {
     let compat_string = match fs_read(
-        &Path::new(config::SYSFS_PREFIX)
+        &Path::new(config::FPGA_MANAGERS_DIR)
             .join(device_handle)
             .join("of_node/compatible"),
     ) {

--- a/src/platforms/universal.rs
+++ b/src/platforms/universal.rs
@@ -61,8 +61,7 @@ impl Platform for UniversalPlatform {
 
         if !parent_path.exists() {
             return Err(FpgadError::Argument(format!(
-                "The overlayfs path {:?} doesn't seem to exist.",
-                parent_path
+                "The overlayfs path {parent_path:?} doesn't seem to exist."
             )));
         }
         Ok(handler)

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -138,8 +138,7 @@ impl Fpga for UniversalFPGA {
 
         let relative_path = stripped_path.to_str().ok_or_else(|| {
             FpgadError::Argument(format!(
-                "Stripped bitstream path {:?} is not valid UTF-8",
-                stripped_path
+                "Stripped bitstream path {stripped_path:?} is not valid UTF-8"
             ))
         })?;
 

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -70,19 +70,19 @@ impl Fpga for UniversalFPGA {
 
     /// Gets the flags from the hex string stored in the sysfs flags file
     /// e.g. sys/class/fpga_manager/fpga0/flags
-    fn flags(&self) -> Result<isize, FpgadError> {
+    fn flags(&self) -> Result<u32, FpgadError> {
         let flag_path = Path::new(config::SYSFS_PREFIX)
             .join(self.device_handle.clone())
             .join("flags");
         let contents = fs_read(&flag_path)?;
         let trimmed = contents.trim().trim_start_matches("0x");
-        isize::from_str_radix(trimmed, 16)
+        u32::from_str_radix(trimmed, 16)
             .map_err(|_| FpgadError::Flag("Parsing flags failed".into()))
     }
 
     /// Sets the flags in the sysfs flags file (e.g. sys/class/fpga_manager/fpga0/flags)
     /// and verifies the write command stuck by reading it back.
-    fn set_flags(&self, flags: isize) -> Result<(), FpgadError> {
+    fn set_flags(&self, flags: u32) -> Result<(), FpgadError> {
         let flag_path = Path::new(config::SYSFS_PREFIX)
             .join(self.device_handle.clone())
             .join("flags");

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -61,7 +61,7 @@ impl Fpga for UniversalFPGA {
     ///
     /// returns: Result<String, FpgadError>
     fn state(&self) -> Result<String, FpgadError> {
-        let state_path = Path::new(config::SYSFS_PREFIX)
+        let state_path = Path::new(config::FPGA_MANAGERS_DIR)
             .join(self.device_handle.clone())
             .join("state");
         trace!("reading {state_path:?}");
@@ -71,7 +71,7 @@ impl Fpga for UniversalFPGA {
     /// Gets the flags from the hex string stored in the sysfs flags file
     /// e.g. sys/class/fpga_manager/fpga0/flags
     fn flags(&self) -> Result<u32, FpgadError> {
-        let flag_path = Path::new(config::SYSFS_PREFIX)
+        let flag_path = Path::new(config::FPGA_MANAGERS_DIR)
             .join(self.device_handle.clone())
             .join("flags");
         let contents = fs_read(&flag_path)?;
@@ -83,7 +83,7 @@ impl Fpga for UniversalFPGA {
     /// Sets the flags in the sysfs flags file (e.g. sys/class/fpga_manager/fpga0/flags)
     /// and verifies the write command stuck by reading it back.
     fn set_flags(&self, flags: u32) -> Result<(), FpgadError> {
-        let flag_path = Path::new(config::SYSFS_PREFIX)
+        let flag_path = Path::new(config::FPGA_MANAGERS_DIR)
             .join(self.device_handle.clone())
             .join("flags");
         trace!("Writing '{flags}' to '{flag_path:?}");
@@ -127,12 +127,12 @@ impl Fpga for UniversalFPGA {
     /// Note: always load firmware before overlay.
     fn load_firmware(&self, bitstream_path: &Path) -> Result<(), FpgadError> {
         let stripped_path = bitstream_path
-            .strip_prefix(config::FW_PREFIX)
+            .strip_prefix(config::FIRMWARE_SOURCE_DIR)
             .map_err(|_| {
                 FpgadError::Argument(format!(
                     "Bitstream path {:?} is not under the configured firmware directory '{}'",
                     bitstream_path,
-                    config::FW_PREFIX
+                    config::FIRMWARE_SOURCE_DIR
                 ))
             })?;
 
@@ -142,7 +142,7 @@ impl Fpga for UniversalFPGA {
             ))
         })?;
 
-        let control_path = Path::new(config::SYSFS_PREFIX)
+        let control_path = Path::new(config::FPGA_MANAGERS_DIR)
             .join(self.device_handle())
             .join("firmware");
         fs_write(&control_path, false, relative_path)?;

--- a/src/platforms/universal_components/universal_overlay_handler.rs
+++ b/src/platforms/universal_components/universal_overlay_handler.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 /// device, overlay or bitstream, and so the handle is specified by the user here and the rest
 /// is fixed.
 fn construct_overlay_fs_path(overlay_handle: &str) -> PathBuf {
-    let overlay_fs_path = PathBuf::from(config::CONFIGFS_PREFIX).join(overlay_handle);
+    let overlay_fs_path = PathBuf::from(config::OVERLAY_CONTROL_DIR).join(overlay_handle);
     trace!("overlay_fs_path will be {overlay_fs_path:?}");
     overlay_fs_path
 }

--- a/src/platforms/universal_components/universal_overlay_handler.rs
+++ b/src/platforms/universal_components/universal_overlay_handler.rs
@@ -41,8 +41,7 @@ impl UniversalOverlayHandler {
     fn check_source_path(&self, source_path: &Path) -> Result<(), FpgadError> {
         if !source_path.exists() | source_path.is_dir() {
             return Err(FpgadError::Argument(format!(
-                "Overlay file '{:?}' has invalid path.",
-                source_path
+                "Overlay file '{source_path:?}' has invalid path."
             )));
         }
         trace!("{source_path:?} appears to be valid overlay source");
@@ -50,14 +49,14 @@ impl UniversalOverlayHandler {
     }
     fn get_vfs_status(&self) -> Result<String, FpgadError> {
         let status_path = self.overlay_fs_path()?.join("status");
-        trace!("Reading from {:?}", status_path);
+        trace!("Reading from {status_path:?}");
         fs_read(&status_path).map(|s| s.trim_end_matches('\n').to_string())
     }
     /// Read path from <overlay_fs_path>/path file and verify that what was meant to be applied
     /// was applied.
     fn get_vfs_path(&self) -> Result<String, FpgadError> {
         let path_path = self.overlay_fs_path()?.join("path");
-        trace!("Reading from {:?}", path_path);
+        trace!("Reading from {path_path:?}");
         fs_read(&path_path).map(|s| s.trim_end_matches('\n').to_string())
     }
 
@@ -67,11 +66,10 @@ impl UniversalOverlayHandler {
         let path_file_contents = self.get_vfs_path()?;
         let dtbo_file_name = extract_filename(source_path)?;
         if path_file_contents.contains(dtbo_file_name) {
-            info!("overlay path contents is valid: '{}'", path_file_contents);
+            info!("overlay path contents is valid: '{path_file_contents}'");
         } else {
             return Err(FpgadError::OverlayStatus(format!(
-                "When trying to apply overlay '{}', the resulting vfs path contained '{}'",
-                dtbo_file_name, path_file_contents
+                "When trying to apply overlay '{dtbo_file_name}', the resulting vfs path contained '{path_file_contents}'"
             )));
         }
 
@@ -82,8 +80,7 @@ impl UniversalOverlayHandler {
             }
             false => {
                 return Err(FpgadError::OverlayStatus(format!(
-                    "After writing to configfs, overlay status does not show 'applied'. Instead it is '{}'",
-                    status
+                    "After writing to configfs, overlay status does not show 'applied'. Instead it is '{status}'"
                 )));
             }
         }
@@ -109,7 +106,7 @@ impl OverlayHandler for UniversalOverlayHandler {
         }
 
         fs_create_dir(overlay_fs_path)?;
-        trace!("Created dir {:?}", overlay_fs_path);
+        trace!("Created dir {overlay_fs_path:?}");
 
         let overlay_path_file = overlay_fs_path.join("path");
         if !overlay_path_file.exists() {
@@ -124,10 +121,7 @@ impl OverlayHandler for UniversalOverlayHandler {
         let dtbo_file_name = extract_filename(source_path)?;
         match fs_write(&overlay_path_file, false, dtbo_file_name) {
             Ok(_) => {
-                trace!(
-                    "'{}' successfully written to {:?}",
-                    dtbo_file_name, overlay_path_file
-                );
+                trace!("'{dtbo_file_name}' successfully written to {overlay_path_file:?}");
             }
             Err(e) => return Err(e),
         }
@@ -154,7 +148,7 @@ impl OverlayHandler for UniversalOverlayHandler {
         };
         let path = self.get_vfs_path()?;
         let status = self.get_vfs_status()?;
-        Ok(format!("{:?} {}", path, status))
+        Ok(format!("{path:?} {status}"))
     }
 
     /// Checks that the overlay_fs_path is stored at time of call and returns it if so (unwraps Option into Result)

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -10,12 +10,13 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
+use crate::config;
 use crate::error::FpgadError;
 use log::trace;
 use std::fs::OpenOptions;
 use std::fs::{create_dir_all, remove_dir};
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Convenient wrapper for reading the contents of `file_path` to String
 pub fn fs_read(file_path: &Path) -> Result<String, FpgadError> {
@@ -100,4 +101,24 @@ pub fn extract_filename(path: &Path) -> Result<&str, FpgadError> {
         .ok_or_else(|| FpgadError::Internal(format!("No filename in path: {:?}", path)))?
         .to_str()
         .ok_or_else(|| FpgadError::Internal(format!("Filename not UTF-8: {:?}", path)))
+}
+
+/// Helper function to check that a device with given handle does exist.
+pub(crate) fn validate_device_handle(device_handle: &str) -> Result<(), FpgadError> {
+    if device_handle.is_empty() || !device_handle.is_ascii() {
+        return Err(FpgadError::Argument(format!(
+            "{device_handle} is invalid name for fpga device.\
+                fpga name must be compliant with sysfs rules."
+        )));
+    }
+    let fpga_managers_dir = config::SYSFS_PREFIX;
+    if !PathBuf::from(fpga_managers_dir)
+        .join(device_handle)
+        .exists()
+    {
+        return Err(FpgadError::Argument(format!(
+            "Device {device_handle} not found."
+        )));
+    };
+    Ok(())
 }

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -27,9 +27,11 @@ pub fn fs_read(file_path: &Path) -> Result<String, FpgadError> {
         .open(file_path)
         .and_then(|mut f| f.read_to_string(&mut buf));
 
-    // do checks on the data we got if necessary
     match result {
-        Ok(_) => Ok(buf),
+        Ok(_) => {
+            trace!("Reading done");
+            Ok(buf)
+        }
         Err(e) => Err(FpgadError::IORead {
             file: file_path.into(),
             e,
@@ -144,7 +146,6 @@ fn read_firmware_source_dir() -> Result<String, FpgadError> {
     fs_read(fw_lookup_override)
 }
 
-#[allow(dead_code)]
 /// Convenient wrapper for reading contents of a directory
 pub fn fs_read_dir(dir: &Path) -> Result<Vec<String>, FpgadError> {
     trace!("Attempting to read directory '{dir:?}'");

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 
 /// Convenient wrapper for reading the contents of `file_path` to String
 pub fn fs_read(file_path: &Path) -> Result<String, FpgadError> {
-    trace!("Attempting to read from {:?}", file_path);
+    trace!("Attempting to read from {file_path:?}");
     let mut buf: String = String::new();
     let result = OpenOptions::new()
         .read(true)
@@ -65,11 +65,11 @@ pub fn fs_write(file_path: &Path, create: bool, value: impl AsRef<str>) -> Resul
 
 /// Convenient wrapper for recursively creating directories up to `path`
 pub fn fs_create_dir(path: &Path) -> Result<(), FpgadError> {
-    trace!("Attempting to Create '{:?}'", path);
+    trace!("Attempting to Create '{path:?}'");
     let result = create_dir_all(path);
     match result {
         Ok(_) => {
-            trace!("Directory created at {:?}.", path);
+            trace!("Directory created at {path:?}.");
             Ok(())
         }
         Err(e) => Err(FpgadError::IOCreate {
@@ -81,11 +81,11 @@ pub fn fs_create_dir(path: &Path) -> Result<(), FpgadError> {
 
 /// Convenient wrapper for deleting an "empty" directory - works for overlayfs
 pub fn fs_remove_dir(path: &Path) -> Result<(), FpgadError> {
-    trace!("Attempting to delete '{:?}'", path);
+    trace!("Attempting to delete '{path:?}'");
     let result = remove_dir(path);
     match result {
         Ok(_) => {
-            trace!("Deleted {:?}", path);
+            trace!("Deleted {path:?}");
             Ok(())
         }
         Err(e) => Err(FpgadError::IODelete {
@@ -98,9 +98,9 @@ pub fn fs_remove_dir(path: &Path) -> Result<(), FpgadError> {
 /// Helper function to extract the filename from a path and wrap the errors
 pub fn extract_filename(path: &Path) -> Result<&str, FpgadError> {
     path.file_name()
-        .ok_or_else(|| FpgadError::Internal(format!("No filename in path: {:?}", path)))?
+        .ok_or_else(|| FpgadError::Internal(format!("No filename in path: {path:?}")))?
         .to_str()
-        .ok_or_else(|| FpgadError::Internal(format!("Filename not UTF-8: {:?}", path)))
+        .ok_or_else(|| FpgadError::Internal(format!("Filename not UTF-8: {path:?}")))
 }
 
 /// Helper function to check that a device with given handle does exist.

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -133,6 +133,7 @@ fn write_firmware_source_dir(new_path: &str) -> Result<(), FpgadError> {
     let fw_lookup_override = Path::new(config::FIRMWARE_LOC_CONTROL_PATH);
     fs_write(fw_lookup_override, false, new_path)
 }
+
 #[allow(dead_code)]
 fn read_firmware_source_dir() -> Result<String, FpgadError> {
     trace!(
@@ -141,4 +142,26 @@ fn read_firmware_source_dir() -> Result<String, FpgadError> {
     );
     let fw_lookup_override = Path::new(config::FIRMWARE_LOC_CONTROL_PATH);
     fs_read(fw_lookup_override)
+}
+
+#[allow(dead_code)]
+/// Convenient wrapper for reading contents of a directory
+pub fn fs_read_dir(dir: &Path) -> Result<Vec<String>, FpgadError> {
+    trace!("Attempting to read directory '{dir:?}'");
+    std::fs::read_dir(dir).map_or_else(
+        |e| {
+            Err(FpgadError::IOReadDir {
+                dir: dir.to_owned(),
+                e,
+            })
+        },
+        |iter| {
+            let ret = iter
+                .filter_map(Result::ok)
+                .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                .collect();
+            trace!("Dir reading done.");
+            Ok(ret)
+        },
+    )
 }

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -111,7 +111,7 @@ pub(crate) fn validate_device_handle(device_handle: &str) -> Result<(), FpgadErr
                 fpga name must be compliant with sysfs rules."
         )));
     }
-    let fpga_managers_dir = config::SYSFS_PREFIX;
+    let fpga_managers_dir = config::FPGA_MANAGERS_DIR;
     if !PathBuf::from(fpga_managers_dir)
         .join(device_handle)
         .exists()

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -122,3 +122,23 @@ pub(crate) fn validate_device_handle(device_handle: &str) -> Result<(), FpgadErr
     };
     Ok(())
 }
+
+#[allow(dead_code)]
+fn write_firmware_source_dir(new_path: &str) -> Result<(), FpgadError> {
+    trace!(
+        "Writing fw prefix {} to {}",
+        new_path,
+        config::FIRMWARE_LOC_CONTROL_PATH
+    );
+    let fw_lookup_override = Path::new(config::FIRMWARE_LOC_CONTROL_PATH);
+    fs_write(fw_lookup_override, false, new_path)
+}
+#[allow(dead_code)]
+fn read_firmware_source_dir() -> Result<String, FpgadError> {
+    trace!(
+        "Reading fw prefix from {}",
+        config::FIRMWARE_LOC_CONTROL_PATH
+    );
+    let fw_lookup_override = Path::new(config::FIRMWARE_LOC_CONTROL_PATH);
+    fs_read(fw_lookup_override)
+}


### PR DESCRIPTION
This used to be a chain of nice atomic changes but now it has become a mega PR, sorry.

This includes all refactors and other changes which are necessary in future PRs.
The main changes are:
- overlay commands now require platform compat string instead of device handle
- these compat strings can now be fetched through the status interface
- the static path strings are renamed
- flags uses u32 now
- created a config git component, although the config system is gone now, it may return.
- fs_read_dir, write_firmware_control and read_firmware_control all added to system_io.rs
- control_interface and status_interface now separate files