### PR TITLE
platforms: dbus: load firmware/apply overlay now lock so that the writes are atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ To do this, device tree of the system must be changed (overlaid).
 This device tree tells Ubuntu a lot of information about the device, such as how much ram the system has.
 It should be clear to see, then, that compromising the device tree is very powerful.
 
+# Key considerations
+
+#### fw_search_path:
+
+The kernel system only works with relative paths and searches relative to provided `fw_search_path` and hardcoded
+firmware
+locations see [the kernel docs](https://docs.kernel.org/driver-api/firmware/fw_search_path.html) for details. When
+loading an overlay, only the relative path of the loaded overlay file is retrievable. If there is a file with the same
+name in the default search paths (such as `/lib/firmware`), there is no guarantee that the loaded file is the one
+provided by the user since the system will successfully load from there even in the event that the file is not present
+at the provided path. It is up to the user to verify that the correct overlay is applied, such as by checking that the
+appropriate drivers are loaded.
+
 # Anticipated Architecture
 
 ![anticipated_architecture.png](docs/assets/anticipated_architecture.png)
@@ -83,9 +96,13 @@ busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonic
 ```
 sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control SetFpgaFlags sx "fpga0" 0
 
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control ApplyOverlay sss "fpga0" "fpga0" "/lib/firmware/k26-starter-kits.dtbo"
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control ApplyOverlay ssss "xlnx" "fpga0" "/lib/firmware/k26-starter-kits.dtbo" ""
 
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteBitstreamDirect ss "fpga0" "/lib/firmware/k26-starter-kits.bit.bin"
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteBitstreamDirect ssss "" "fpga0" "/lib/firmware/k26-starter-kits.bit.bin" ""
 
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control RemoveOverlay ss "fpga0" "fpga0"
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control ApplyOverlay ssss "xlnx" "fpga0" "/lib/firmware/xilinx/k26-starter-kits/k26_starter_kits.dtbo" "/lib/firmware/xilinx/k26-starter-kits"
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteBitstreamDirect ssss "" "fpga0" "/lib/firmware/xilinx/k26-starter-kits/k26_starter_kits.bit.bin" "/lib/firmware/"
+
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control RemoveOverlay ss "xlnx" "fpga0"
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,6 @@
 //
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
-pub static FIRMWARE_SOURCE_DIR: &str = "/lib/firmware/";
 pub static FPGA_MANAGERS_DIR: &str = "/sys/class/fpga_manager/";
 pub static OVERLAY_CONTROL_DIR: &str = "/sys/kernel/config/device-tree/overlays/";
 pub static FIRMWARE_LOC_CONTROL_PATH: &str = "/sys/module/firmware_class/parameters/path";

--- a/src/platforms/platform.rs
+++ b/src/platforms/platform.rs
@@ -74,7 +74,7 @@ pub trait Fpga {
     fn set_flags(&self, flags: u32) -> Result<(), FpgadError>;
     #[allow(dead_code)]
     /// Directly load the firmware stored in bitstream_path to the device
-    fn load_firmware(&self, bitstream_path: &Path) -> Result<(), FpgadError>;
+    fn load_firmware(&self, bitstream_path_rel: &Path) -> Result<(), FpgadError>;
 }
 
 pub trait OverlayHandler {
@@ -159,7 +159,8 @@ pub fn platform_from_compat_or_device(
         false => platform_for_known_platform(platform_string),
     }
 }
-fn platform_for_device(device_handle: &str) -> Result<Box<dyn Platform>, FpgadError> {
+
+pub fn platform_for_device(device_handle: &str) -> Result<Box<dyn Platform>, FpgadError> {
     Ok(new_platform(discover_platform_type(device_handle)?))
 }
 
@@ -174,5 +175,5 @@ pub trait Platform {
     /// creates and inits an Fpga if not present otherwise gets the instance
     fn fpga(&self, device_handle: &str) -> Result<&dyn Fpga, FpgadError>;
     /// creates and inits an OverlayHandler if not present otherwise gets the instance
-    fn overlay_handler(&self, overlay_handle: &str) -> Result<&dyn OverlayHandler, FpgadError>;
+    fn overlay_handler(&self, overlay_handle: &str) -> Result<&(dyn OverlayHandler), FpgadError>;
 }

--- a/src/platforms/universal.rs
+++ b/src/platforms/universal.rs
@@ -48,7 +48,7 @@ impl Platform for UniversalPlatform {
     }
 
     /// Gets the `overlay_handler` associated with this device.
-    fn overlay_handler(&self, overlay_handle: &str) -> Result<&dyn OverlayHandler, FpgadError> {
+    fn overlay_handler(&self, overlay_handle: &str) -> Result<&(dyn OverlayHandler), FpgadError> {
         // TODO: replace the return type of UniversalOverlayHandler to Result and use
         // get_or_try_init instead here when stable:
         // https://github.com/rust-lang/rust/issues/121641

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -125,27 +125,11 @@ impl Fpga for UniversalFPGA {
 
     /// This can be used to manually load a firmware if the overlay does not trigger the load.
     /// Note: always load firmware before overlay.
-    fn load_firmware(&self, bitstream_path: &Path) -> Result<(), FpgadError> {
-        let stripped_path = bitstream_path
-            .strip_prefix(config::FIRMWARE_SOURCE_DIR)
-            .map_err(|_| {
-                FpgadError::Argument(format!(
-                    "Bitstream path {:?} is not under the configured firmware directory '{}'",
-                    bitstream_path,
-                    config::FIRMWARE_SOURCE_DIR
-                ))
-            })?;
-
-        let relative_path = stripped_path.to_str().ok_or_else(|| {
-            FpgadError::Argument(format!(
-                "Stripped bitstream path {stripped_path:?} is not valid UTF-8"
-            ))
-        })?;
-
+    fn load_firmware(&self, bitstream_path_rel: &Path) -> Result<(), FpgadError> {
         let control_path = Path::new(config::FPGA_MANAGERS_DIR)
             .join(self.device_handle())
             .join("firmware");
-        fs_write(&control_path, false, relative_path)?;
+        fs_write(&control_path, false, bitstream_path_rel.to_string_lossy())?;
         self.assert_state()
     }
 }

--- a/src/platforms/universal_components/universal_overlay_handler.rs
+++ b/src/platforms/universal_components/universal_overlay_handler.rs
@@ -13,7 +13,7 @@
 use crate::config;
 use crate::error::FpgadError;
 use crate::platforms::platform::OverlayHandler;
-use crate::system_io::{extract_filename, fs_create_dir, fs_read, fs_remove_dir, fs_write};
+use crate::system_io::{fs_create_dir, fs_read, fs_remove_dir, fs_write};
 use log::{info, trace};
 use std::path::{Path, PathBuf};
 
@@ -37,16 +37,6 @@ pub struct UniversalOverlayHandler {
 }
 
 impl UniversalOverlayHandler {
-    /// setter for the stored overlay_source_path. Checks the file exists directly after assignment.
-    fn check_source_path(&self, source_path: &Path) -> Result<(), FpgadError> {
-        if !source_path.exists() | source_path.is_dir() {
-            return Err(FpgadError::Argument(format!(
-                "Overlay file '{source_path:?}' has invalid path."
-            )));
-        }
-        trace!("{source_path:?} appears to be valid overlay source");
-        Ok(())
-    }
     fn get_vfs_status(&self) -> Result<String, FpgadError> {
         let status_path = self.overlay_fs_path()?.join("status");
         trace!("Reading from {status_path:?}");
@@ -54,22 +44,22 @@ impl UniversalOverlayHandler {
     }
     /// Read path from <overlay_fs_path>/path file and verify that what was meant to be applied
     /// was applied.
-    fn get_vfs_path(&self) -> Result<String, FpgadError> {
+    fn get_vfs_path(&self) -> Result<PathBuf, FpgadError> {
         let path_path = self.overlay_fs_path()?.join("path");
         trace!("Reading from {path_path:?}");
-        fs_read(&path_path).map(|s| s.trim_end_matches('\n').to_string())
+        let path_string = fs_read(&path_path).map(|s| s.trim_end_matches('\n').to_string())?;
+        Ok(PathBuf::from(path_string))
     }
 
     /// When an overlay fails to be applied, it may show as "applied" status but the path will
     /// be empty. Therefore, this checks both match what is expected.
-    fn vfs_check_applied(&self, source_path: &Path) -> Result<(), FpgadError> {
+    fn vfs_check_applied(&self, source_path_rel: &Path) -> Result<(), FpgadError> {
         let path_file_contents = self.get_vfs_path()?;
-        let dtbo_file_name = extract_filename(source_path)?;
-        if path_file_contents.contains(dtbo_file_name) {
-            info!("overlay path contents is valid: '{path_file_contents}'");
+        if source_path_rel.ends_with(&path_file_contents) {
+            info!("overlay path contents is valid: '{path_file_contents:?}'");
         } else {
             return Err(FpgadError::OverlayStatus(format!(
-                "When trying to apply overlay '{dtbo_file_name}', the resulting vfs path contained '{path_file_contents}'"
+                "When trying to apply overlay '{source_path_rel:?}', the resulting vfs path contained '{path_file_contents:?}'"
             )));
         }
 
@@ -94,9 +84,7 @@ impl OverlayHandler for UniversalOverlayHandler {
     /// There are multiple ways to trigger a firmware load so this is not valid if the
     /// dtbo doesn't contain a firmware to load.
     /// Calls prepare_for_load to ensure paths are valid etc. beforehand.
-    fn apply_overlay(&self, source_path: &Path) -> Result<(), FpgadError> {
-        self.check_source_path(source_path)?;
-
+    fn apply_overlay(&self, source_path_rel: &Path) -> Result<(), FpgadError> {
         let overlay_fs_path = self.overlay_fs_path()?;
         if overlay_fs_path.exists() {
             return Err(FpgadError::Argument(format!(
@@ -118,14 +106,13 @@ impl OverlayHandler for UniversalOverlayHandler {
             )));
         }
 
-        let dtbo_file_name = extract_filename(source_path)?;
-        match fs_write(&overlay_path_file, false, dtbo_file_name) {
+        match fs_write(&overlay_path_file, false, source_path_rel.to_string_lossy()) {
             Ok(_) => {
-                trace!("'{dtbo_file_name}' successfully written to {overlay_path_file:?}");
+                trace!("'{source_path_rel:?}' successfully written to {overlay_path_file:?}");
             }
             Err(e) => return Err(e),
         }
-        self.vfs_check_applied(source_path)
+        self.vfs_check_applied(source_path_rel)
     }
 
     /// Attempts to delete overlay_fs_path

--- a/src/system_io.rs
+++ b/src/system_io.rs
@@ -97,12 +97,24 @@ pub fn fs_remove_dir(path: &Path) -> Result<(), FpgadError> {
     }
 }
 
-/// Helper function to extract the filename from a path and wrap the errors
-pub fn extract_filename(path: &Path) -> Result<&str, FpgadError> {
-    path.file_name()
-        .ok_or_else(|| FpgadError::Internal(format!("No filename in path: {path:?}")))?
-        .to_str()
-        .ok_or_else(|| FpgadError::Internal(format!("Filename not UTF-8: {path:?}")))
+pub fn extract_path_and_filename(path: &Path) -> Result<(PathBuf, PathBuf), FpgadError> {
+    // Extract filename
+    let filename = path
+        .file_name()
+        .and_then(|f| f.to_str())
+        .ok_or(FpgadError::Argument(format!(
+            "Provided bitstream path {path:?} is missing filename."
+        )))?;
+
+    // Extract parent directory
+    let base_path = path
+        .parent()
+        .and_then(|p| p.to_str())
+        .ok_or(FpgadError::Argument(format!(
+            "Provided bitstream path {path:?} is missing a parent dir."
+        )))?;
+
+    Ok((base_path.into(), filename.into()))
 }
 
 /// Helper function to check that a device with given handle does exist.
@@ -125,8 +137,7 @@ pub(crate) fn validate_device_handle(device_handle: &str) -> Result<(), FpgadErr
     Ok(())
 }
 
-#[allow(dead_code)]
-fn write_firmware_source_dir(new_path: &str) -> Result<(), FpgadError> {
+pub fn write_firmware_source_dir(new_path: &str) -> Result<(), FpgadError> {
     trace!(
         "Writing fw prefix {} to {}",
         new_path,
@@ -137,7 +148,7 @@ fn write_firmware_source_dir(new_path: &str) -> Result<(), FpgadError> {
 }
 
 #[allow(dead_code)]
-fn read_firmware_source_dir() -> Result<String, FpgadError> {
+pub fn read_firmware_source_dir() -> Result<String, FpgadError> {
     trace!(
         "Reading fw prefix from {}",
         config::FIRMWARE_LOC_CONTROL_PATH

--- a/tests/concurent_load/test_concurrent_load.sh
+++ b/tests/concurent_load/test_concurrent_load.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/bash
+
+
+NUM_WORKERS=50
+
+cmd1='sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteBitstreamDirect ssss "" "fpga0" "/lib/firmware/xilinx/k26-starter-kits/k26_starter_kits.bit.bin" "/lib/firmware/xilinx/k26-starter-kits/"'
+
+cmd2='sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteBitstreamDirect ssss "" "fpga0" "/lib/firmware/k26-starter-kits.bit.bin" ""
+            '
+
+# Spawn
+for i in $(seq 1 $NUM_WORKERS); do
+    eval "$cmd1" &
+    eval "$cmd2" &
+done
+
+wait
+
+echo "Finished running $((NUM_WORKERS)) concurrent D-Bus calls."


### PR DESCRIPTION
this is necessary to avoid concurrent writes to /sys/module/firmware_class/parameters/path