### PR TITLE
root: app: update snapcraft file to expose cli and dbus daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FPGAd
 
+[![fpgad](https://snapcraft.io/fpgad/badge.svg)](https://snapcraft.io/fpgad)
+
 FPGAd is a WIP rust project.
 It provides a strictly confined snap which will provide a mechanism to dynamically load and unload bitstreams to FPGA
 devices on Ubuntu Core.
@@ -7,9 +9,9 @@ It mitigates the need for other snaps containing bitstreams to have super privil
 Instead, those other snaps will connect to FPGAd and FPGAd will have the necessary privileges.
 This is for several reasons, but mostly to:
 
-1) make the snap store team happy (not publishing lots of super privileged snaps).
-2) add a place for checking and verifying bitstreams before loading them for additional safety/security.
-3) make it easier to port already existing bitstream packages to snap store.
+1. make the snap store team happy (not publishing lots of super privileged snaps).
+2. add a place for checking and verifying bitstreams before loading them for additional safety/security.
+3. make it easier to port already existing bitstream packages to snap store.
 
 In order to understand why the super privileges are necessary, you must understand that loading a bitstream
 fundamentally changes the FPGA device's behaviour including what the connections to the CPU are/do.
@@ -37,24 +39,24 @@ sudo cp ./data/dbus/com.canonical.fpgad.conf /etc/dbus-1/system.d/
 
 #### FPGA only:
 
-1) control.SetFpgaFlags(fpga_handle, flags)
-2) control.WriteBitstreamDirect(fpga_handle, bitstream_path)
+1. control.SetFpgaFlags(fpga_handle, flags)
+2. control.WriteBitstreamDirect(fpga_handle, bitstream_path)
 
 #### Overlay only:
 
-1) status.GetOverlayStatus(overlay_handle) <- check doesn't exist
-2) control.SetFpgaFlags(device_handle, flags) <- does check for sticking internally
-3) control.CreateOverlay(overlay_handle) <- just makes a dir and checks the subsystem created the internal files
-4) control.ApplyOverlay(overlay_handle, dtbo_path) <- writes dtbo_path to overlay and asserts overlay status
-5) status.GetFpgaState(fpga_handle) <- check it is `operating`
+1. status.GetOverlayStatus(overlay_handle) <- check doesn't exist
+2. control.SetFpgaFlags(device_handle, flags) <- does check for sticking internally
+3. control.CreateOverlay(overlay_handle) <- just makes a dir and checks the subsystem created the internal files
+4. control.ApplyOverlay(overlay_handle, dtbo_path) <- writes dtbo_path to overlay and asserts overlay status
+5. status.GetFpgaState(fpga_handle) <- check it is `operating`
 
 #### Combined:
 
-1) control.SetFpgaFlags(device_handle, flags) <- >does check for sticking internally
-2) control.WriteBitstreamDirect
-3) control.CreateOverlay(overlay_handle) <- just makes a dir and checks the subsystem created the internal files
-4) control.ApplyOverlay(overlay_handle, dtbo_path) <- writes dtbo_path to overlay and asserts overlay status
-5) status.GetFpgaState(fpga_handle) <- check it is `operating`
+1. control.SetFpgaFlags(device_handle, flags) <- >does check for sticking internally
+2. control.WriteBitstreamDirect
+3. control.CreateOverlay(overlay_handle) <- just makes a dir and checks the subsystem created the internal files
+4. control.ApplyOverlay(overlay_handle, dtbo_path) <- writes dtbo_path to overlay and asserts overlay status
+5. status.GetFpgaState(fpga_handle) <- check it is `operating`
 
 #### Removing:
 
@@ -62,7 +64,7 @@ The FPGA subsystem does not have a way to remove an overlay. Instead, you must w
 
 To remove an overlay simply call:
 
-1) control.RemoveOverlay(overlay_handle)
+1. control.RemoveOverlay(overlay_handle)
 
 # Busctrl Call Examples
 
@@ -85,5 +87,5 @@ sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.c
 
 sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteBitstreamDirect ss "fpga0" "/lib/firmware/k26-starter-kits.bit.bin"
 
-sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control RemoveOverlay ss "fpga0" "fpga0" 
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control RemoveOverlay ss "fpga0" "fpga0"
 ```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,14 +1,26 @@
-name: fpgad # you probably want to 'snapcraft register <name>'
-base: core24 # the base snap is the execution environment for this snap
+name: fpgad
+base: core24
 adopt-info: version
 summary: An FPGA manager daemon that handles the dirty work for you
 description: |
   An FPGA manager daemon that handles the dirty work for you.
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: devmode # use 'strict' once you have the right plugs and slots
+slots:
+  dbus-daemon:
+    interface: dbus
+    bus: system
+    name: com.canonical.fpgad
 apps:
   fpgad:
+    command: bin/cli
+  daemon:
     command: bin/fpgad
+    daemon: simple
+    restart-condition: always
+    start-timeout: 30s
+    install-mode: enable
+    bus-name: com.canonical.fpgad
 parts:
   version:
     plugin: nil
@@ -19,7 +31,15 @@ parts:
       craftctl default
       cargo_version=$(cargo metadata --no-deps --format-version 1 | jq -r .packages[0].version)
       craftctl set version="$cargo_version+git$(date +'%Y%m%d').$(git describe --always --exclude '*')"
+  # with `snapcraft remote-build` cargo build with workspace is not working as
+  # it is in local builds so keeping the parts separated to make sure `remote-build`
+  # also works as expected. see: https://github.com/canonical/fpgad/pull/52
+  # for details.
+  cli:
+    plugin: rust
+    source: .
+    rust-path:
+      - cli
   fpgad:
-    # See 'snapcraft plugins'
     plugin: rust
     source: .


### PR DESCRIPTION
Updated snapcraft file as explained in title. `cli` application frontend is available and we dont need backend to be completed to start exposing it. In addition to that I also updated the daemon configuration so system dbus service is up and running when the fpgad snap is installed. I used `busctl` to check if it accessible and it looks like the connection is there and busctl is able to find the application in classic ubuntu installations.