### PR TITLE
root: update pre-commit hooks to check licenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.licensesnip
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.licensesnip
+++ b/.licensesnip
@@ -1,0 +1,11 @@
+This file is part of fpgad, an application to manage FPGA subsystem together with device-tree and kernel modules.
+
+Copyright 2025 Canonical Ltd.
+
+SPDX-License-Identifier: GPL-3.0-only
+
+fpgad is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 3, as published by the Free Software Foundation.
+
+fpgad is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranties of MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,9 @@ repos:
       - id: ruff-format
         args:
           - --check
+  - repo: https://github.com/notken12/licensesnip
+    rev: f01f898 # pre-commit hooks is not tagged yet
+    hooks:
+      - id: licensesnip
+        args:
+          - 'check'


### PR DESCRIPTION
Added licensesnip hook to check if we have license header for all source files we have.