### PR TITLE
root: app: configure snap to start before connected dbus plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,8 @@ parts:
     source: .
     rust-path:
       - cli
+    rust-channel: "stable"
   fpgad:
     plugin: rust
     source: .
+    rust-channel: "stable"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,11 +16,15 @@ apps:
     command: bin/cli
   daemon:
     command: bin/fpgad
-    daemon: simple
+    daemon: dbus
     restart-condition: always
     start-timeout: 30s
     install-mode: enable
     bus-name: com.canonical.fpgad
+    slots:
+      - dbus-daemon
+    activates-on:
+      - dbus-daemon
 parts:
   version:
     plugin: nil


### PR DESCRIPTION
without this change, the daemon could start after any client snaps.

the adding `rust-channel` is to suppress a warning/error