### PR TITLE
root: app: remove redundant `bus-name` key

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,6 @@ apps:
     restart-condition: always
     start-timeout: 30s
     install-mode: enable
-    bus-name: com.canonical.fpgad
     slots:
       - dbus-daemon
     plugs:


### PR DESCRIPTION
`bus-name` is overridden  by `activates-on` so removing for disambiguity