### PR TITLE
dbus: implement a generic call for reading and writing to fpga_manager properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.c
 sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control RemoveOverlay ss "xlnx" "fpga0"
 ```
 
+#### other properties
+
+The virtual files cotaineed within `/sys/class/fpga_manager/fpga*/`, which do not have specific interfaces, can be
+access by using ReadProperty or WriteProperty e.g.
+
+```shell
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/status com.canonical.fpgad.status ReadProperty s "/sys/class/fpga_manager/fpga0/name"
+```
+
+```shell
+sudo busctl call --system com.canonical.fpgad /com/canonical/fpgad/control com.canonical.fpgad.control WriteProperty ss "/sys/class/fpga_manager/fpga0/key" ""
+```
+
 # Snap
 
 ```shell

--- a/src/comm/dbus/status_interface.rs
+++ b/src/comm/dbus/status_interface.rs
@@ -11,10 +11,13 @@
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
 use crate::config;
+use crate::config::FPGA_MANAGERS_DIR;
+use crate::error::FpgadError;
 use crate::platforms::platform::{list_fpga_managers, read_compatible_string};
 use crate::platforms::platform::{platform_for_known_platform, platform_from_compat_or_device};
-use crate::system_io::{fs_read_dir, validate_device_handle};
+use crate::system_io::{fs_read, fs_read_dir, validate_device_handle};
 use log::{error, trace};
+use std::path::Path;
 use zbus::{fdo, interface};
 
 pub struct StatusInterface {}
@@ -88,7 +91,15 @@ impl StatusInterface {
         Ok(ret_string)
     }
 
-    async fn get_platform_name(&self, _device_handle: &str) -> Result<String, fdo::Error> {
-        todo!()
+    /// use to read a device property from /sys/class/fpga_manager/<device>/** that does not have a specific interface
+    async fn read_property(&self, property_path_str: &str) -> Result<String, fdo::Error> {
+        trace!("read_property called with property_path_str: {property_path_str}");
+        let property_path = Path::new(property_path_str);
+        if !property_path.starts_with(Path::new(FPGA_MANAGERS_DIR)) {
+            return Err(fdo::Error::from(FpgadError::Argument(format!(
+                "Cannot access property {property_path_str}: does not begin with {FPGA_MANAGERS_DIR}"
+            ))));
+        }
+        Ok(fs_read(property_path)?)
     }
 }


### PR DESCRIPTION
not all the virtual files in ``/sys/class/fpga_manager/fgpa*/` were writable via dbus so instead of adding new interfaces for all of these, we add a generic call which allows read/write to these variables