### PR TITLE
app: add fpgad_macros with platform macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,10 +325,19 @@ name = "fpgad"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "fpgad_macros",
  "log",
  "thiserror",
  "tokio",
  "zbus",
+]
+
+[[package]]
+name = "fpgad_macros"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,10 @@ readme = "README.md"
 
 [workspace]
 resolver = "3"
-members = ["cli"]
+members = ["cli", "fpgad_macros"]
 
 [dependencies]
+fpgad_macros = { path = "fpgad_macros" }
 log = "0.4.27"
 env_logger = "0.11.8"
 tokio = { version = "1.46.1", features = ["full"] }

--- a/fpgad_macros/Cargo.toml
+++ b/fpgad_macros/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fpgad_macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2"
+quote = "1"

--- a/fpgad_macros/src/lib.rs
+++ b/fpgad_macros/src/lib.rs
@@ -1,0 +1,43 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Expr, ItemStruct, Lit, Meta, parse_macro_input, punctuated::Punctuated};
+
+#[proc_macro_attribute]
+pub fn platform(args: TokenStream, input: TokenStream) -> TokenStream {
+    // Parse the struct
+    let input_struct = parse_macro_input!(input as ItemStruct);
+    let struct_name = &input_struct.ident;
+
+    // Parse the attribute arguments
+    let args = parse_macro_input!(args with Punctuated::<Meta, syn::Token![,]>::parse_terminated);
+
+    let mut compat_string: Option<String> = None;
+    for arg in args {
+        if let Meta::NameValue(nv) = arg {
+            if nv.path.is_ident("compat_string") {
+                if let Expr::Lit(lit_expr) = nv.value {
+                    if let Lit::Str(litstr) = lit_expr.lit {
+                        compat_string = Some(litstr.value());
+                    }
+                }
+            }
+        }
+    }
+    let compat_string = compat_string.expect("compat_string must be provided");
+
+    // Generate code to register the platform
+    let expanded = quote! {
+        #input_struct
+
+        impl #struct_name {
+            #[doc(hidden)]
+            pub fn register_platform() {
+                crate::platforms::platform::register_platform(
+                    #compat_string,
+                    || Box::new(Self::new())
+                );
+            }
+        }
+    };
+    TokenStream::from(expanded)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,16 +25,13 @@ mod system_io;
 
 use crate::{
     comm::dbus::{control_interface::ControlInterface, status_interface::StatusInterface},
-    platforms::{platform::register_platform, universal::UniversalPlatform},
+    platforms::universal::UniversalPlatform,
     softeners::xilinx_dfx_mgr::XilinxDfxMgrPlatform,
 };
 
 fn register_platforms() {
-    // TODO: implement a proc_macro that registers the platform with compat string
-    register_platform("xlnx,zynqmp-pcap-fpga,versal-fpga,zynq-devcfg-1.0", || {
-        Box::new(XilinxDfxMgrPlatform::new())
-    });
-    register_platform("universal", || Box::new(UniversalPlatform::new()));
+    XilinxDfxMgrPlatform::register_platform();
+    UniversalPlatform::register_platform();
 }
 
 #[tokio::main]

--- a/src/platforms/universal.rs
+++ b/src/platforms/universal.rs
@@ -14,9 +14,11 @@ use crate::error::FpgadError;
 use crate::platforms::platform::{Fpga, OverlayHandler, Platform};
 use crate::platforms::universal_components::universal_fpga::UniversalFPGA;
 use crate::platforms::universal_components::universal_overlay_handler::UniversalOverlayHandler;
+use fpgad_macros::platform;
 use log::trace;
 use std::sync::OnceLock;
 
+#[platform(compat_string = "universal")]
 #[derive(Debug)]
 pub struct UniversalPlatform {
     fpga: OnceLock<UniversalFPGA>,

--- a/src/softeners/xilinx_dfx_mgr.rs
+++ b/src/softeners/xilinx_dfx_mgr.rs
@@ -20,14 +20,14 @@ use crate::platforms::platform::Platform;
 use crate::platforms::universal_components::universal_fpga::UniversalFPGA;
 use crate::platforms::universal_components::universal_overlay_handler::UniversalOverlayHandler;
 use crate::softeners::error::FpgadSoftenerError;
+use fpgad_macros::platform;
 
+#[platform(compat_string = "xlnx,zynqmp-pcap-fpga,versal-fpga,zynq-devcfg-1.0")]
 pub struct XilinxDfxMgrPlatform {
     fpga: OnceLock<UniversalFPGA>,
     overlay_handler: OnceLock<UniversalOverlayHandler>,
 }
 
-// TODO: implement a proc_macro that registers the platform with compat string
-//#[platform(compat_string = "xlnx,zynqmp-pcap-fpga,versal-fpga,zynq-devcfg-1.0")]
 impl XilinxDfxMgrPlatform {
     pub fn new() -> Self {
         trace!("creating new XilinxDfxMgrPlatform");


### PR DESCRIPTION
Introducing `#[platform(compat_string="...")]` macro for platforms to be
registered into fpgad system. `platform` is an attribute proc_macro
it creates a registration function with given compatible string. I didnt
want to add another new dependency so I didnt used `ctor` in this commit
which would allow us to automatically register platforms. But with this
implementation we need to call register_platform function manually in
main application.
