### PR TITLE
softeners: platforms: use `ctor` to register platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "ctor"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4735f265ba6a1188052ca32d461028a7d1125868be18e287e756019da7607b5"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
+
+[[package]]
+name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+
+[[package]]
 name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +355,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 name = "fpgad"
 version = "0.1.0"
 dependencies = [
+ "ctor",
  "env_logger",
  "fpgad_macros",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = ["cli", "fpgad_macros"]
 
 [dependencies]
 fpgad_macros = { path = "fpgad_macros" }
+ctor = "0.4.2"
 log = "0.4.27"
 env_logger = "0.11.8"
 tokio = { version = "1.46.1", features = ["full"] }

--- a/fpgad_macros/src/lib.rs
+++ b/fpgad_macros/src/lib.rs
@@ -24,19 +24,23 @@ pub fn platform(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     }
     let compat_string = compat_string.expect("compat_string must be provided");
+    let register_fn_name = syn::Ident::new(
+        &format!("{struct_name}_register_platform"),
+        struct_name.span(),
+    );
 
     // Generate code to register the platform
     let expanded = quote! {
         #input_struct
 
-        impl #struct_name {
-            #[doc(hidden)]
-            pub fn register_platform() {
-                crate::platforms::platform::register_platform(
-                    #compat_string,
-                    || Box::new(Self::new())
-                );
-            }
+        #[doc(hidden)]
+        #[allow(non_snake_case)]
+        #[ctor::ctor]
+        fn #register_fn_name() {
+            crate::platforms::platform::register_platform(
+                #compat_string,
+                || Box::new(#struct_name::new())
+            );
         }
     };
     TokenStream::from(expanded)

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,21 +23,11 @@ mod platforms;
 mod softeners;
 mod system_io;
 
-use crate::{
-    comm::dbus::{control_interface::ControlInterface, status_interface::StatusInterface},
-    platforms::universal::UniversalPlatform,
-    softeners::xilinx_dfx_mgr::XilinxDfxMgrPlatform,
-};
-
-fn register_platforms() {
-    XilinxDfxMgrPlatform::register_platform();
-    UniversalPlatform::register_platform();
-}
+use crate::comm::dbus::{control_interface::ControlInterface, status_interface::StatusInterface};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
-    register_platforms();
 
     // Upon load, the daemon will search each fpga device and determine what platform it is
     // based on its name in /sys/class/fpga_manager/{device}/name

--- a/src/softeners/xilinx_dfx_mgr.rs
+++ b/src/softeners/xilinx_dfx_mgr.rs
@@ -37,6 +37,7 @@ impl XilinxDfxMgrPlatform {
         }
     }
 }
+
 impl Platform for XilinxDfxMgrPlatform {
     fn fpga(
         &self,


### PR DESCRIPTION
`ctor` is a library that marks a function or static variable as a library/executable constructor. This uses OS-specific linker sections to call a specific function at load time.

---

Let's also discuss the need for `ctor`, I dont really want to add more dependencies into the project but I can understand the benefit this brings. It helps integrating more platforms easier and also prevents small mistakes such as adding a platform but not really registering it. 

But it also adds a bit of magic into the application as well so it hides the implementation detail of registering platforms from the developer.

So I feel like this is a nice to have feature but not really mandatory.