### PR TITLE
platforms: dbus: cli: minor fixes

### DIFF
--- a/cli/src/proxies/control_proxy.rs
+++ b/cli/src/proxies/control_proxy.rs
@@ -17,8 +17,13 @@ use zbus::{Result, proxy};
     default_path = "/com/canonical/fpgad/control"
 )]
 pub trait Control {
-    async fn load_defaults(&self) -> Result<String>;
-    async fn set_fpga_flags(&self, device_handle: &str, flags: u32) -> Result<String>;
+    async fn set_fpga_flags(
+        &self,
+        platform_string: &str,
+        device_handle: &str,
+        flags: u32,
+    ) -> Result<String>;
+
     async fn write_bitstream_direct(
         &self,
         platform_string: &str,
@@ -36,4 +41,6 @@ pub trait Control {
     ) -> Result<String>;
 
     async fn remove_overlay(&self, platform_str: &str, overlay_handle: &str) -> Result<String>;
+
+    async fn write_property(&self, property_path_str: &str, data: &str) -> Result<String>;
 }

--- a/src/comm/dbus/control_interface.rs
+++ b/src/comm/dbus/control_interface.rs
@@ -38,7 +38,6 @@ fn make_firmware_pair(
     if firmware_path.as_os_str().is_empty() {
         return extract_path_and_filename(source_path);
     }
-
     if let Ok(suffix) = source_path.strip_prefix(firmware_path) {
         // Remove leading '/' if present
         let cleaned_suffix_path = suffix
@@ -147,7 +146,11 @@ impl ControlInterface {
     }
 
     /// use to write to a device property from /sys/class/fpga_manager/<device>/** that does not have a specific interface
-    async fn write_property(&self, property_path_str: &str, data: &str) -> Result<(), fdo::Error> {
+    async fn write_property(
+        &self,
+        property_path_str: &str,
+        data: &str,
+    ) -> Result<String, fdo::Error> {
         trace!(
             "write_property called with property_path_str: {property_path_str} and data: {data}"
         );
@@ -157,6 +160,7 @@ impl ControlInterface {
                 "Cannot access property {property_path_str}: does not begin with {FPGA_MANAGERS_DIR}"
             ))));
         }
-        Ok(fs_write(property_path, false, data)?)
+        fs_write(property_path, false, data)?;
+        Ok(format!("{data} written to {property_path_str}"))
     }
 }

--- a/src/platforms/universal_components/universal_fpga.rs
+++ b/src/platforms/universal_components/universal_fpga.rs
@@ -14,7 +14,7 @@ use crate::config;
 use crate::error::FpgadError;
 use crate::platforms::platform::Fpga;
 use crate::system_io::{fs_read, fs_write};
-use log::{error, info, trace};
+use log::{error, info, trace, warn};
 use std::path::Path;
 
 #[derive(Debug)]
@@ -101,7 +101,7 @@ impl Fpga for UniversalFPGA {
                     )
                 }
                 _ => {
-                    error!(
+                    warn!(
                         "{}'s state is '{}' after writing flags.",
                         self.device_handle, state
                     );


### PR DESCRIPTION
- update proxies in cli
- return String from write_property (Result<String, fdo::Error>)
- replace an error! with warn! (directly after boot, fpga0 state is "unknown" to write_flags misreported as error)