### PR TITLE
workflows: test only unit tests in the linter step

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -161,5 +161,5 @@ jobs:
       - name: Run unit tests
         run: |-
           echo "::group::unit test results"
-          cargo test
+          cargo test --bins
           echo "::endgroup::"


### PR DESCRIPTION
needed because integration tests must be run on kria DUT