### PR TITLE
workflows: add snap build to linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -141,6 +141,12 @@ jobs:
           echo "::group::yamlfmt output"
           yamlfmt -lint .
           echo "::endgroup::"
+  snap-check:
+    name: Check Snap Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: canonical/action-build@v1.3.0
   rust-check:
     name: Check Rust Code
     runs-on: ubuntu-latest


### PR DESCRIPTION
This make sures that the changes are not breaking snap build.