### PR TITLE
root: snap - add strict confinement using interfaces

### DIFF
--- a/daemon/src/comm/dbus/control_interface.rs
+++ b/daemon/src/comm/dbus/control_interface.rs
@@ -73,7 +73,7 @@ impl ControlInterface {
         platform.fpga(device_handle)?.load_firmware(&suffix)?;
         Ok(format!(
             "{bitstream_path_str} loaded to {device_handle} using firmware lookup path: '\
-         {firmware_lookup_path}'"
+         {prefix:?}'"
         ))
     }
 
@@ -109,7 +109,7 @@ impl ControlInterface {
         overlay_handler.apply_overlay(&suffix)?;
         Ok(format!(
             "{overlay_source_path} loaded via {overlay_fs_path:?} using firmware lookup path: '\
-         {firmware_lookup_path}'"
+         {prefix:?}'"
         ))
     }
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ summary: An FPGA manager daemon that handles the dirty work for you
 description: |
   An FPGA manager daemon that handles the dirty work for you.
 grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode # use 'strict' once you have the right plugs and slots
+confinement: strict # use 'strict' once you have the right plugs and slots
 source-code:
   - https://github.com/canonical/fpgad
 license: GPL-3.0
@@ -17,6 +17,13 @@ slots:
     interface: dbus
     bus: system
     name: com.canonical.fpgad
+plugs:
+  device-tree-overlays:
+    interface: system-files
+    read:
+      - /sys/kernel/config/device-tree/overlays
+    write:
+      - /sys/kernel/config/device-tree/overlays
 apps:
   fpgad:
     command: bin/cli
@@ -30,6 +37,8 @@ apps:
       - dbus-daemon
     plugs:
       - fpga
+      - kernel-firmware-control
+      - device-tree-overlays
     activates-on:
       - dbus-daemon
 parts:


### PR DESCRIPTION
new interfaces
- device-tree-overlays which is system-files for overlay control
- kernel-firmware-control for firmware lookup path