### PR TITLE
root: snap - add device-tree-overlays system-files interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,12 @@ plugs:
   provider-content:
     interface: content
     target: $SNAP_DATA/provider-content
+  device-tree-overlays:
+    interface: system-files
+    read:
+      - /sys/kernel/config/device-tree/overlays
+    write:
+      - /sys/kernel/config/device-tree/overlays
 apps:
   fpgad:
     command: bin/cli


### PR DESCRIPTION
required for device tree overlay control