### PR TITLE
root: upgrade snap grade to stable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ adopt-info: version
 summary: An FPGA manager daemon that handles the dirty work for you
 description: |
   An FPGA manager daemon that handles the dirty work for you.
-grade: devel # must be 'stable' to release into candidate/stable channels
+grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 source-code:
   - https://github.com/canonical/fpgad
@@ -52,10 +52,10 @@ parts:
     source: .
     rust-path:
       - cli
-    rust-channel: "stable"
+    rust-channel: 'stable'
   fpgad:
     plugin: rust
     source: .
     rust-path:
       - daemon
-    rust-channel: "stable"
+    rust-channel: 'stable'


### PR DESCRIPTION
> Specify the production readiness of your snap. While developing,
leave this set to devel to disable the snapd guardrails. When your snap is ready for release, set it to stable.

I believe our snap is ready for its first `candidate` track release.