### PR TITLE
root: cli: dbus: fix cli failures related to interface limitations on core

### DIFF
--- a/daemon/src/comm/dbus/control_interface.rs
+++ b/daemon/src/comm/dbus/control_interface.rs
@@ -15,7 +15,7 @@ use crate::config::FPGA_MANAGERS_DIR;
 use crate::error::FpgadError;
 use crate::platforms::platform::{platform_for_known_platform, platform_from_compat_or_device};
 use crate::system_io::fs_write;
-use log::trace;
+use log::{info, trace};
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::{Mutex, MutexGuard, OnceCell};
@@ -39,7 +39,7 @@ impl ControlInterface {
         device_handle: &str,
         flags: u32,
     ) -> Result<String, fdo::Error> {
-        trace!("set_fpga_flags called with name: {device_handle} and flags: {flags}");
+        info!("set_fpga_flags called with name: {device_handle} and flags: {flags}");
         validate_device_handle(device_handle)?;
         let platform = platform_from_compat_or_device(platform_string, device_handle)?;
         platform.fpga(device_handle)?.set_flags(flags)?;
@@ -53,9 +53,7 @@ impl ControlInterface {
         bitstream_path_str: &str,
         firmware_lookup_path: &str,
     ) -> Result<String, fdo::Error> {
-        trace!(
-            "load_firmware called with name: {device_handle} and path_str: {bitstream_path_str}"
-        );
+        info!("load_firmware called with name: {device_handle} and path_str: {bitstream_path_str}");
         validate_device_handle(device_handle)?;
         let path = Path::new(bitstream_path_str);
         if !path.exists() || path.is_dir() {
@@ -84,7 +82,7 @@ impl ControlInterface {
         overlay_source_path: &str,
         firmware_lookup_path: &str,
     ) -> Result<String, fdo::Error> {
-        trace!(
+        info!(
             "apply_overlay called with platform_compat_str: {platform_compat_str}, overlay_handle: \
             {overlay_handle} and overlay_path: {overlay_source_path}",
         );
@@ -118,7 +116,7 @@ impl ControlInterface {
         platform_compat_str: &str,
         overlay_handle: &str,
     ) -> Result<String, fdo::Error> {
-        trace!(
+        info!(
             "remove_overlay called with platform_compat_str: {platform_compat_str} and overlay_handle:\
              {overlay_handle}"
         );
@@ -137,9 +135,7 @@ impl ControlInterface {
         property_path_str: &str,
         data: &str,
     ) -> Result<String, fdo::Error> {
-        trace!(
-            "write_property called with property_path_str: {property_path_str} and data: {data}"
-        );
+        info!("write_property called with property_path_str: {property_path_str} and data: {data}");
         let property_path = Path::new(property_path_str);
         if !property_path.starts_with(Path::new(FPGA_MANAGERS_DIR)) {
             return Err(fdo::Error::from(FpgadError::Argument(format!(

--- a/daemon/src/comm/dbus/status_interface.rs
+++ b/daemon/src/comm/dbus/status_interface.rs
@@ -17,7 +17,7 @@ use crate::platforms::platform::{platform_for_known_platform, platform_from_comp
 use crate::comm::dbus::{fs_read_property, validate_device_handle};
 use crate::error::FpgadError;
 use crate::system_io::fs_read_dir;
-use log::{error, trace};
+use log::{error, info};
 use zbus::{fdo, interface};
 
 pub struct StatusInterface {}
@@ -29,7 +29,7 @@ impl StatusInterface {
         platform_string: &str,
         device_handle: &str,
     ) -> Result<String, fdo::Error> {
-        trace!("get_fpga_state called with name: {device_handle}");
+        info!("get_fpga_state called with name: {device_handle}");
         validate_device_handle(device_handle)?;
         let platform = platform_from_compat_or_device(platform_string, device_handle)?;
         Ok(platform.fpga(device_handle)?.state()?)
@@ -40,7 +40,7 @@ impl StatusInterface {
         platform_string: &str,
         device_handle: &str,
     ) -> Result<String, fdo::Error> {
-        trace!("get_fpga_flags called with name: {device_handle}");
+        info!("get_fpga_flags called with name: {device_handle}");
         validate_device_handle(device_handle)?;
         let platform = platform_from_compat_or_device(platform_string, device_handle)?;
         Ok(platform
@@ -54,7 +54,7 @@ impl StatusInterface {
         platform_compat_str: &str,
         overlay_handle: &str,
     ) -> Result<String, fdo::Error> {
-        trace!(
+        info!(
             "get_overlay_status called with platform_compat_str: {platform_compat_str} and overlay_handle:\
              {overlay_handle}"
         );
@@ -70,20 +70,20 @@ impl StatusInterface {
     }
 
     async fn get_overlays(&self) -> Result<String, fdo::Error> {
-        trace!("get_overlays called");
+        info!("get_overlays called");
         let overlay_handles = fs_read_dir(config::OVERLAY_CONTROL_DIR.as_ref())?;
         Ok(overlay_handles.join("\n"))
     }
 
     async fn get_platform_type(&self, device_handle: &str) -> Result<String, fdo::Error> {
-        trace!("get_platform_type called with device_handle: {device_handle}");
+        info!("get_platform_type called with device_handle: {device_handle}");
         validate_device_handle(device_handle)?;
         let ret_string = read_compatible_string(device_handle)?;
         Ok(ret_string.to_string())
     }
 
     async fn get_platform_types(&self) -> Result<String, fdo::Error> {
-        trace!("get_platform_types called");
+        info!("get_platform_types called");
         let mut ret_string = String::new();
         let devices = list_fpga_managers()?;
         for device_handle in devices {
@@ -99,7 +99,7 @@ impl StatusInterface {
 
     /// use to read a device property from /sys/class/fpga_manager/<device>/** that does not have a specific interface
     async fn read_property(&self, property_path_str: &str) -> Result<String, fdo::Error> {
-        trace!("read_property called with property_path_str: {property_path_str}");
+        info!("read_property called with property_path_str: {property_path_str}");
         Ok(fs_read_property(property_path_str)?)
     }
 }

--- a/fpgad_macros/Cargo.toml
+++ b/fpgad_macros/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2024"
 proc-macro = true
 
 [dependencies]
-syn = "2"
+syn = { version = "2", features = ["full"] }
 quote = "1"

--- a/fpgad_macros/src/lib.rs
+++ b/fpgad_macros/src/lib.rs
@@ -13,14 +13,12 @@ pub fn platform(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let mut compat_string: Option<String> = None;
     for arg in args {
-        if let Meta::NameValue(nv) = arg {
-            if nv.path.is_ident("compat_string") {
-                if let Expr::Lit(lit_expr) = nv.value {
-                    if let Lit::Str(litstr) = lit_expr.lit {
-                        compat_string = Some(litstr.value());
-                    }
-                }
-            }
+        if let Meta::NameValue(nv) = arg
+            && nv.path.is_ident("compat_string")
+            && let Expr::Lit(ref lit_expr) = nv.value
+            && let Lit::Str(ref litstr) = lit_expr.lit
+        {
+            compat_string = Some(litstr.value());
         }
     }
     let compat_string = compat_string.expect("compat_string must be provided");

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,9 +17,16 @@ slots:
     interface: dbus
     bus: system
     name: com.canonical.fpgad
+plugs:
+  fpgad-dbus:
+    interface: dbus
+    bus: system
+    name: com.canonical.fpgad
 apps:
   fpgad:
     command: bin/cli
+    plugs:
+      - fpgad-dbus
   daemon:
     command: bin/fpgad
     daemon: dbus
@@ -31,6 +38,7 @@ apps:
     plugs:
       - fpga
       - kernel-firmware-control
+      - hardware-observe
     activates-on:
       - dbus-daemon
 parts:


### PR DESCRIPTION
- add hardware-observe to enable access to pcap/compatible
- add dbus plug for cli to connect to daemon 
- add catch for get_overlays failure due to no overlayfs interface

while I was debugging, I remembered that everything is trace, but we default to info level. We should do a proper audit of what should be info and what should be trace/debug. For now I added the "<interface> called with <inputs>" prints info which was really helpful when debugging the issue.