### PR TITLE
root: snap - just add content interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,9 @@ plugs:
     interface: dbus
     bus: system
     name: com.canonical.fpgad
+  provider-content:
+    interface: content
+    target: $SNAP_DATA/provider-content
 apps:
   fpgad:
     command: bin/cli


### PR DESCRIPTION
named "provider-content" because it will connected to like `snap connect my-app:my-content fpgad:provider-content` (so need for fpgad in the name) and it will not only be bitstreams, but also overlays and maybe even dkms modules