### PR TITLE
tests: fail the workflow if the tests failed but finished

### DIFF
--- a/.github/testflinger-assets/device-script.sh
+++ b/.github/testflinger-assets/device-script.sh
@@ -15,4 +15,5 @@ tar -xzvf fpgad.gz
 
 echo "INFO: Running test script"
 cd fpgad
-./tests/coverage_test.sh
+mkdir -p artifacts
+./tests/coverage_test.sh 2>&1 | tee artifacts/coverage_test.log

--- a/.github/testflinger-assets/testflinger_job.yaml
+++ b/.github/testflinger-assets/testflinger_job.yaml
@@ -1,4 +1,4 @@
-job_queue: xilinx-kv260-c34038
+job_queue: xilinx-kv260-c36973
 provision_data:
   url: https://tel-image-cache.canonical.com/oem-share/limerick/kria-24.04/classic-24.04-x07/iot-limerick-kria-classic-server-2404-classic-24.04-x07-20250423.img.xz
 test_data:

--- a/.github/workflows/integration_tests.yaml.yml
+++ b/.github/workflows/integration_tests.yaml.yml
@@ -70,5 +70,14 @@ jobs:
         shell: bash
         run: |
           if [ "${{ steps.submit.outcome }}" != "success" ]; then
+            echo "::error::test job didn't complete successfully"
+            exit 1
+          fi
+          if [[ ! -f artifacts/coverage_test.log ]]; then
+            echo "::error::coverage_test.log not found, did the tests fail to start?"
+            exit 1
+          fi
+          if grep -q "test result: FAILED" artifacts/coverage_test.log; then
+            echo "::error::found failure phrase in coverage_test.log"
             exit 1
           fi

--- a/daemon/src/platforms/platform.rs
+++ b/daemon/src/platforms/platform.rs
@@ -83,7 +83,7 @@ pub trait Platform: Any {
     /// creates and inits an Fpga if not present otherwise gets the instance
     fn fpga(&self, device_handle: &str) -> Result<&dyn Fpga, FpgadError>;
     /// creates and inits an OverlayHandler if not present otherwise gets the instance
-    fn overlay_handler(&self, overlay_handle: &str) -> Result<&(dyn OverlayHandler), FpgadError>;
+    fn overlay_handler(&self, overlay_handle: &str) -> Result<&dyn OverlayHandler, FpgadError>;
 }
 
 fn match_platform_string(platform_string: &str) -> Result<Box<dyn Platform>, FpgadError> {

--- a/daemon/src/platforms/universal.rs
+++ b/daemon/src/platforms/universal.rs
@@ -49,7 +49,7 @@ impl Platform for UniversalPlatform {
     }
 
     /// Gets the `overlay_handler` associated with this device.
-    fn overlay_handler(&self, overlay_handle: &str) -> Result<&(dyn OverlayHandler), FpgadError> {
+    fn overlay_handler(&self, overlay_handle: &str) -> Result<&dyn OverlayHandler, FpgadError> {
         // TODO: replace the return type of UniversalOverlayHandler to Result and use
         // get_or_try_init instead here when stable:
         // https://github.com/rust-lang/rust/issues/121641

--- a/daemon/src/softeners/xilinx_dfx_mgr.rs
+++ b/daemon/src/softeners/xilinx_dfx_mgr.rs
@@ -54,7 +54,7 @@ impl Platform for XilinxDfxMgrPlatform {
     fn overlay_handler(
         &self,
         overlay_handle: &str,
-    ) -> Result<&(dyn crate::platforms::platform::OverlayHandler), crate::error::FpgadError> {
+    ) -> Result<&dyn crate::platforms::platform::OverlayHandler, crate::error::FpgadError> {
         Ok(self
             .overlay_handler
             .get_or_init(|| UniversalOverlayHandler::new(overlay_handle)))

--- a/daemon/tests/universal/control/set_fpga_flags.rs
+++ b/daemon/tests/universal/control/set_fpga_flags.rs
@@ -33,7 +33,7 @@ use zbus::Result;
     0,
     err(displays_as(contains_substring("FpgadError::Argument:")))
 )]
-#[case::no_platform_str("", "fpga0", 0, ok(contains_substring("Flags set to 0 for fpga0")))]
+#[case::no_platform_str("", "fpga0", 0, ok(contains_substring("Flags set to 0x0 for fpga0")))]
 #[case::max_u32_val(
     PLATFORM_STRING,
     "fpga0",
@@ -50,7 +50,7 @@ use zbus::Result;
     PLATFORM_STRING,
     "fpga0",
     0,
-    ok(contains_substring("Flags set to 0 for fpga0"))
+    ok(contains_substring("Flags set to 0x0 for fpga0"))
 )]
 async fn cases<M: for<'a> Matcher<&'a Result<String>>>(
     #[case] platform_string: &str,


### PR DESCRIPTION
- Duplicates the script's output into a file to search for "test result: FAILED" amongst the test logs.
- Fixed the tests (was searching for 0 in flags setting but this changed to "0x0" (and we didn't notice because the tests were passing accidentally
- Linter updates was printing warnings on build so ran --fix on that.