### PR TITLE
cli: add support for loading files from current directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__/
 
 # IDE files
 .idea
+
+# local data
+sandbox/

--- a/daemon/src/comm/dbus/control_interface.rs
+++ b/daemon/src/comm/dbus/control_interface.rs
@@ -56,12 +56,6 @@ impl ControlInterface {
         info!("load_firmware called with name: {device_handle} and path_str: {bitstream_path_str}");
         validate_device_handle(device_handle)?;
         let path = Path::new(bitstream_path_str);
-        if !path.exists() || path.is_dir() {
-            return Err(FpgadError::Argument(format!(
-                "{bitstream_path_str} is not a valid path to a bitstream file."
-            ))
-            .into());
-        }
         let _guard = get_write_lock_guard().await;
         let platform = platform_from_compat_or_device(platform_string, device_handle)?;
         let (prefix, suffix) = make_firmware_pair(path, Path::new(firmware_lookup_path))?;
@@ -86,13 +80,6 @@ impl ControlInterface {
             "apply_overlay called with platform_compat_str: {platform_compat_str}, overlay_handle: \
             {overlay_handle} and overlay_path: {overlay_source_path}",
         );
-        let path = Path::new(overlay_source_path);
-        if !path.exists() || path.is_dir() {
-            return Err(FpgadError::Argument(format!(
-                "{overlay_source_path} is not a valid path to an overlay file."
-            ))
-            .into());
-        }
         let _guard = get_write_lock_guard().await;
         let platform = platform_for_known_platform(platform_compat_str)?;
         let overlay_handler = platform.overlay_handler(overlay_handle)?;

--- a/daemon/tests/universal/control/write_bitstream_direct.rs
+++ b/daemon/tests/universal/control/write_bitstream_direct.rs
@@ -31,9 +31,9 @@ use zbus::Connection;
 #[case::bad_path(
     PLATFORM_STRING,
     "fpga0",
-    "k26_starter_kits.bit.bin",
+    "this_file_does_not_exist.bit.bin",
     "",
-    err(displays_as(contains_substring("FpgadError::Argument:")))
+    err(displays_as(contains_substring("FpgadError::IOWrite:")))
 )]
 async fn should_fail_not_timeout<M: for<'a> Matcher<&'a zbus::Result<String>>>(
     #[case] platform_str: &str,

--- a/daemon/tests/universal/sequences/overlay_management.rs
+++ b/daemon/tests/universal/sequences/overlay_management.rs
@@ -205,14 +205,13 @@ async fn overlay_already_applied(_setup: ()) {
 #[tokio::test]
 #[gtest]
 #[rstest]
-#[case::bad_dtbo_path("fpga0", "universal", "/lib/firmware/k26-starter-kits")]
 #[case::no_dtbo_path("fpga0", "universal", "")]
 #[case::bad_platform_string("fpga0", "platform", "/lib/firmware/k26-starter-kits.dtbo")]
 #[case::no_platform_string("fpga0", "", "/lib/firmware/k26-starter-kits.dtbo")]
 #[case::no_overlay_handle("", "universal", "/lib/firmware/k26-starter-kits.dtbo")]
 /// fails if an overlay cannot be applied, and will succeed if the overlay is applied, and then
 /// trying to apply it again fails. This test made the "default working case" redundant
-async fn bad_inputs(
+async fn argument_errors(
     #[case] overlay_handle: &str,
     #[case] platform_handle: &str,
     #[case] overlay_file: &str,
@@ -274,6 +273,96 @@ async fn bad_inputs(
     assert_that!(
         &r,
         err(displays_as(contains_substring("FpgadError::Argument: "))),
+    );
+    if !overlay_handle.is_empty() {
+        let s = status_proxy
+            .get_overlay_status(good_platform_handle, overlay_handle)
+            .await
+            .expect("failed to read overlay status");
+        expect_that!(s, contains_substring("not present"));
+    }
+
+    // remove if applied by accident
+    let _ = control_proxy
+        .remove_overlay(good_platform_handle, overlay_handle)
+        .await;
+    if !overlay_handle.is_empty() {
+        let s = status_proxy
+            .get_overlay_status(good_platform_handle, overlay_handle)
+            .await
+            .expect("failed to read overlay status");
+        expect_that!(s, contains_substring("not present"));
+    }
+}
+
+#[tokio::test]
+#[gtest]
+#[rstest]
+#[case::bad_dtbo_path("fpga0", "universal", "/lib/firmware/bad-dtbo-path")]
+async fn io_errors(
+    #[case] overlay_handle: &str,
+    #[case] platform_handle: &str,
+    #[case] overlay_file: &str,
+    _setup: (),
+) {
+    // good variables used to check status etc
+    let good_device_handle: &str = "fpga0";
+    let good_platform_handle: &str = "universal";
+
+    let connection = Connection::system()
+        .await
+        .expect("failed to create connection");
+    let control_proxy = control_proxy::ControlProxy::new(&connection)
+        .await
+        .expect("failed to create control proxy");
+    let status_proxy = status_proxy::StatusProxy::new(&connection)
+        .await
+        .expect("failed to create status proxy");
+
+    // remove any and all overlays
+    for overlay_handle in status_proxy
+        .get_overlays()
+        .await
+        .expect("failed to get overlays")
+        .split(",")
+    {
+        if !overlay_handle.is_empty() {
+            control_proxy
+                .remove_overlay(good_platform_handle, overlay_handle)
+                .await
+                .unwrap_or_else(|_| panic!("failed to remove {overlay_handle}"));
+        }
+    }
+
+    // reset flags
+    control_proxy
+        .set_fpga_flags(good_platform_handle, good_device_handle, 0)
+        .await
+        .expect("failed to set fpga flags");
+    expect_that!(
+        status_proxy
+            .get_fpga_flags(good_platform_handle, good_device_handle)
+            .await
+            .expect("failed to get fpga flags"),
+        eq("0"),
+        "flags not set properly"
+    );
+
+    // reset encryption key
+    control_proxy
+        .write_property("/sys/class/fpga_manager/fpga0/key", "")
+        .await
+        .expect("failed to reset the encryption key");
+
+    // write a bad overlay path
+    let r = control_proxy
+        .apply_overlay(platform_handle, overlay_handle, overlay_file, "")
+        .await;
+    assert_that!(
+        &r,
+        err(displays_as(contains_substring(
+            "FpgadError::OverlayStatus: "
+        ))),
     );
     if !overlay_handle.is_empty() {
         let s = status_proxy


### PR DESCRIPTION
N.B. if the path is inavlid, there is no longer a nice printout saying so because of snap confinement. Instead, it shows as a IOWrite error:
```
[<timestamp> ERROR cli] org.freedesktop.DBus.Error.IOError: FpgadError::IOWrite: An IO error occurred when writing "<filename>" to "/sys/class/fpga_manager/<dev_handle>/firmware": No such file or directory (os error 2)
```