### PR TITLE
root: macros version has to be explicitly set for publish to work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/canonical/fpgad"
 authors = ["Talha Can Havadar <talha.can.havadar@canonical.com>", "Artie Poole <stuart.poole@canonical.com>"]
 
 [workspace.dependencies]
-fpgad_macros = { path = "fpgad_macros" }
+fpgad_macros = { version = "0.1.1", path = "fpgad_macros" }
 


### PR DESCRIPTION
Error before fix:
10:56:14 [  0] → cargo publish --dry-run
    Updating crates.io index
error: failed to verify manifest at `/home/stuart.poole@canonical.com/source/canonical/fpgad/daemon/Cargo.toml`

Caused by:
  all dependencies must have a version requirement specified when publishing.
  dependency `fpgad_macros` does not specify a version
  Note: The published dependency will use the version from crates.io,
  the `path` specification will be removed from the dependency declaration.