### PR TITLE
workflows: Add release and cargo publish workflows

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -1,0 +1,118 @@
+name: Publish crates
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to publish (without leading v, for example 0.1.1)'
+        required: true
+        type: string
+      commit_sha:
+        description: 'Commit SHA to publish from'
+        required: true
+        type: string
+      mode:
+        description: 'dry-run validates publish flow, publish uploads to crates.io'
+        required: false
+        default: dry-run
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (without leading v, for example 0.1.1)'
+        required: true
+      commit_sha:
+        description: 'Commit SHA to publish from'
+        required: true
+      mode:
+        description: 'dry-run validates publish flow, publish uploads to crates.io'
+        required: true
+        type: choice
+        options:
+          - dry-run
+          - publish
+        default: dry-run
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  publish:
+    name: Publish crates in dependency order
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 0
+      - name: Validate version and mode
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ inputs.version }}"
+          MODE="${{ inputs.mode }}"
+
+          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::Version must be semver-like (example: 0.1.1 or 0.1.1-rc.1)."
+            exit 1
+          fi
+
+          WORKSPACE_VERSION="$({
+            awk '
+              /^\[workspace\.package\]/ { in_section=1; next }
+              in_section && /^\[/ { in_section=0 }
+              in_section && /^version[[:space:]]*=/ {
+                gsub(/.*"/, "", $0)
+                gsub(/".*/, "", $0)
+                print $0
+                exit
+              }
+            ' Cargo.toml
+          })"
+
+          if [[ -z "${WORKSPACE_VERSION}" ]]; then
+            echo "::error::Could not read [workspace.package].version from Cargo.toml."
+            exit 1
+          fi
+
+          if [[ "${WORKSPACE_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::Requested version '${VERSION}' does not match Cargo.toml version '${WORKSPACE_VERSION}'."
+            exit 1
+          fi
+
+          if [[ "${MODE}" != "dry-run" && "${MODE}" != "publish" ]]; then
+            echo "::error::Mode must be either 'dry-run' or 'publish'."
+            exit 1
+          fi
+      - name: Authenticate with crates.io trusted publishing
+        if: ${{ inputs.mode == 'publish' }}
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Run cargo publish steps
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          MODE="${{ inputs.mode }}"
+          PUBLISH_FLAG=""
+
+          if [[ "${MODE}" == "dry-run" ]]; then
+            PUBLISH_FLAG="--dry-run"
+          fi
+
+          if [[ "${MODE}" == "publish" && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+            echo "::error::Trusted publishing token was not generated. Ensure crates.io trusted publishing is configured for this workflow."
+            exit 1
+          fi
+
+          run_publish() {
+            local manifest_path="$1"
+            echo "::group::cargo publish ${manifest_path} (${MODE})"
+            cargo publish --manifest-path "${manifest_path}" --locked ${PUBLISH_FLAG}
+            echo "::endgroup::"
+          }
+
+          run_publish fpgad_macros/Cargo.toml
+          run_publish daemon/Cargo.toml
+          run_publish cli/Cargo.toml

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -38,6 +38,7 @@ jobs:
   publish:
     name: Publish workspace crates
     runs-on: ubuntu-latest
+    environment: cargo-publish
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -8,7 +8,8 @@ on:
         type: string
       commit_sha:
         description: 'Commit SHA to publish from'
-        required: true
+        required: false
+        default: main
         type: string
       mode:
         description: '`dry-run` validates publish flow, `publish` uploads to crates.io'
@@ -22,7 +23,8 @@ on:
         required: true
       commit_sha:
         description: 'Commit SHA to publish from'
-        required: true
+        required: false
+        default: main
       mode:
         description: '`dry-run` validates publish flow, `publish` uploads to crates.io'
         required: true

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -11,7 +11,7 @@ on:
         required: true
         type: string
       mode:
-        description: 'dry-run validates publish flow, publish uploads to crates.io'
+        description: '`dry-run` validates publish flow, `publish` uploads to crates.io'
         required: false
         default: dry-run
         type: string
@@ -24,7 +24,7 @@ on:
         description: 'Commit SHA to publish from'
         required: true
       mode:
-        description: 'dry-run validates publish flow, publish uploads to crates.io'
+        description: '`dry-run` validates publish flow, `publish` uploads to crates.io'
         required: true
         type: choice
         options:
@@ -51,38 +51,12 @@ jobs:
           VERSION="${{ inputs.version }}"
           MODE="${{ inputs.mode }}"
 
-          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.]+)?$ ]]; then
-            echo "::error::Version must be semver-like (example: 0.1.1 or 0.1.1-rc.1)."
-            exit 1
-          fi
-
-          WORKSPACE_VERSION="$({
-            awk '
-              /^\[workspace\.package\]/ { in_section=1; next }
-              in_section && /^\[/ { in_section=0 }
-              in_section && /^version[[:space:]]*=/ {
-                gsub(/.*"/, "", $0)
-                gsub(/".*/, "", $0)
-                print $0
-                exit
-              }
-            ' Cargo.toml
-          })"
-
-          if [[ -z "${WORKSPACE_VERSION}" ]]; then
-            echo "::error::Could not read [workspace.package].version from Cargo.toml."
-            exit 1
-          fi
-
-          if [[ "${WORKSPACE_VERSION}" != "${VERSION}" ]]; then
-            echo "::error::Requested version '${VERSION}' does not match Cargo.toml version '${WORKSPACE_VERSION}'."
-            exit 1
-          fi
-
           if [[ "${MODE}" != "dry-run" && "${MODE}" != "publish" ]]; then
             echo "::error::Mode must be either 'dry-run' or 'publish'."
             exit 1
           fi
+
+          python scripts/ci/check_version_bump.py validate --expected-version "${VERSION}"
       - name: Authenticate with crates.io trusted publishing
         if: ${{ inputs.mode == 'publish' }}
         uses: rust-lang/crates-io-auth-action@v1

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -36,7 +36,7 @@ permissions:
   id-token: write
 jobs:
   publish:
-    name: Publish crates in dependency order
+    name: Publish workspace crates
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -69,10 +69,10 @@ jobs:
           set -euo pipefail
 
           MODE="${{ inputs.mode }}"
-          PUBLISH_FLAG=""
+          PUBLISH_ARGS=(--manifest-path Cargo.toml --workspace --locked)
 
           if [[ "${MODE}" == "dry-run" ]]; then
-            PUBLISH_FLAG="--dry-run"
+            PUBLISH_ARGS+=(--dry-run)
           fi
 
           if [[ "${MODE}" == "publish" && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
@@ -80,13 +80,4 @@ jobs:
             exit 1
           fi
 
-          run_publish() {
-            local manifest_path="$1"
-            echo "::group::cargo publish ${manifest_path} (${MODE})"
-            cargo publish --manifest-path "${manifest_path}" --locked ${PUBLISH_FLAG}
-            echo "::endgroup::"
-          }
-
-          run_publish fpgad_macros/Cargo.toml
-          run_publish daemon/Cargo.toml
-          run_publish cli/Cargo.toml
+          cargo publish "${PUBLISH_ARGS[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       tag_name: ${{ steps.meta.outputs.tag_name }}
       version: ${{ steps.meta.outputs.version }}
       commit_sha: ${{ steps.meta.outputs.commit_sha }}
+      is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,6 +38,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          # Normalize version when triggered by tag push (for example, v0.1.1 -> 0.1.1).
+          if [[ "${VERSION}" == v* ]]; then
+            VERSION="${VERSION#v}"
+          fi
+          TAG_NAME="v${VERSION}"
 
           if ! git cat-file -e "${COMMIT_SHA}^{commit}"; then
             echo "::error::Commit '${COMMIT_SHA}' does not exist in this repository."
@@ -54,18 +61,26 @@ jobs:
 
           python scripts/ci/check_version_bump.py validate --expected-version "${VERSION}" --ref "${COMMIT_SHA}"
 
+          LOWER_VERSION="${VERSION,,}"
+          IS_PRERELEASE="false"
+          if [[ "${LOWER_VERSION}" =~ (alpha|beta|rc|pre|dev|exp|experimental|nightly) ]]; then
+            IS_PRERELEASE="true"
+          fi
+
           {
             echo "tag_name=${TAG_NAME}"
             echo "version=${VERSION}"
             echo "commit_sha=${COMMIT_SHA}"
+            echo "is_prerelease=${IS_PRERELEASE}"
           } >> "${GITHUB_OUTPUT}"
   build:
     name: Build release artifacts
-    runs-on: ubuntu-24.04-arm
+    runs-on: [ubuntu-24.04-arm, ubuntu-latest]
     needs: metadata
     outputs:
       archive_name: ${{ steps.package.outputs.archive_name }}
       checksum_name: ${{ steps.package.outputs.checksum_name }}
+      prerelease_crate_bundle: ${{ steps.prerelease_crates.outputs.bundle_name }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -74,7 +89,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo build --workspace --release --locked
+          cargo build --workspace --release --locked --all-features
       - name: Package artifacts
         id: package
         shell: bash
@@ -103,6 +118,24 @@ jobs:
           path: |
             ${{ steps.package.outputs.archive_name }}
             ${{ steps.package.outputs.checksum_name }}
+      - name: Package prerelease crate bundle
+        if: ${{ needs.metadata.outputs.is_prerelease == 'true' }}
+        id: prerelease_crates
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cargo package --workspace --locked
+
+          BUNDLE_NAME="fpgad-${{ needs.metadata.outputs.version }}-experimental-crates.tar.gz"
+          tar -czf "${BUNDLE_NAME}" -C target/package .
+          echo "bundle_name=${BUNDLE_NAME}" >> "${GITHUB_OUTPUT}"
+      - name: Upload prerelease crate bundle
+        if: ${{ needs.metadata.outputs.is_prerelease == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: prerelease-crates
+          path: ${{ steps.prerelease_crates.outputs.bundle_name }}
   cargo-publish:
     name: Publish crates to crates.io
     needs: metadata
@@ -127,6 +160,12 @@ jobs:
         with:
           name: release-assets
           path: .
+      - name: Download prerelease crate bundle
+        if: ${{ needs.metadata.outputs.is_prerelease == 'true' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: prerelease-crates
+          path: .
       - name: Create GitHub release with gh CLI
         shell: bash
         env:
@@ -134,10 +173,26 @@ jobs:
         run: |
           set -euo pipefail
 
+          IS_PRERELEASE="${{ needs.metadata.outputs.is_prerelease }}"
           ARCHIVE="${{ needs.build.outputs.archive_name }}"
           CHECKSUM="${{ needs.build.outputs.checksum_name }}"
+          ASSETS=("${ARCHIVE}" "${CHECKSUM}")
+          RELEASE_ARGS=(
+            --target "${{ needs.metadata.outputs.commit_sha }}"
+            --generate-notes
+          )
 
-          for asset in "${ARCHIVE}" "${CHECKSUM}"; do
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            EXPERIMENTAL_BUNDLE="${{ needs.build.outputs.prerelease_crate_bundle }}"
+            if [[ -z "${EXPERIMENTAL_BUNDLE}" || ! -f "${EXPERIMENTAL_BUNDLE}" ]]; then
+              echo "::error::Prerelease crate bundle '${EXPERIMENTAL_BUNDLE}' not found."
+              exit 1
+            fi
+            ASSETS+=("${EXPERIMENTAL_BUNDLE}")
+            RELEASE_ARGS+=(--prerelease)
+          fi
+
+          for asset in "${ASSETS[@]}"; do
             if [[ ! -f "${asset}" ]]; then
               echo "::error::Release asset '${asset}' not found."
               exit 1
@@ -145,7 +200,5 @@ jobs:
           done
 
           gh release create "${{ needs.metadata.outputs.tag_name }}" \
-            "${ARCHIVE}" \
-            "${CHECKSUM}" \
-            --target "${{ needs.metadata.outputs.commit_sha }}" \
-            --generate-notes
+            "${ASSETS[@]}" \
+            "${RELEASE_ARGS[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,177 @@
+name: Release tagged version
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (without leading v, for example 0.1.1)'
+        required: true
+      commit_sha:
+        description: 'Commit SHA to build and release'
+        required: true
+permissions:
+  contents: write
+concurrency:
+  group: release-${{ github.ref_name || github.event.inputs.version }}
+  cancel-in-progress: false
+jobs:
+  metadata:
+    name: Resolve release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.meta.outputs.tag_name }}
+      version: ${{ steps.meta.outputs.version }}
+      commit_sha: ${{ steps.meta.outputs.commit_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Resolve and validate release inputs
+        id: meta
+        env:
+          VERSION: ${{ inputs.version || github.ref_name }}
+          COMMIT_SHA: ${{ inputs.commit_sha || github.sha }}
+          TAG_NAME: ${{ inputs.version && format('v{0}', inputs.version) || github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::Version must be semver-like (example: 0.1.1 or 0.1.1-rc.1)."
+            exit 1
+          fi
+
+          if ! git cat-file -e "${COMMIT_SHA}^{commit}"; then
+            echo "::error::Commit '${COMMIT_SHA}' does not exist in this repository."
+            exit 1
+          fi
+
+          COMMIT_SHA="$(git rev-parse "${COMMIT_SHA}^{commit}")"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && git rev-parse -q --verify "refs/tags/${TAG_NAME}" >/dev/null; then
+            TAG_COMMIT_SHA="$(git rev-parse "refs/tags/${TAG_NAME}^{commit}")"
+            if [[ "${TAG_COMMIT_SHA}" != "${COMMIT_SHA}" ]]; then
+              echo "::error::Tag '${TAG_NAME}' already exists and points to ${TAG_COMMIT_SHA}, not ${COMMIT_SHA}."
+              exit 1
+            fi
+          fi
+
+          WORKSPACE_VERSION="$({
+            git show "${COMMIT_SHA}:Cargo.toml" | awk '
+              /^\[workspace\.package\]/ { in_section=1; next }
+              in_section && /^\[/ { in_section=0 }
+              in_section && /^version[[:space:]]*=/ {
+                gsub(/.*"/, "", $0)
+                gsub(/".*/, "", $0)
+                print $0
+                exit
+              }
+            '
+          })"
+
+          if [[ -z "${WORKSPACE_VERSION}" ]]; then
+            echo "::error::Could not read [workspace.package].version from Cargo.toml at ${COMMIT_SHA}."
+            exit 1
+          fi
+
+          if [[ "${WORKSPACE_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::Requested version '${VERSION}' does not match Cargo.toml version '${WORKSPACE_VERSION}' at ${COMMIT_SHA}."
+            exit 1
+          fi
+
+          {
+            echo "tag_name=${TAG_NAME}"
+            echo "version=${VERSION}"
+            echo "commit_sha=${COMMIT_SHA}"
+          } >> "${GITHUB_OUTPUT}"
+  build:
+    name: Build release artifacts
+    runs-on: ubuntu-latest
+    needs: metadata
+    outputs:
+      archive_name: ${{ steps.package.outputs.archive_name }}
+      checksum_name: ${{ steps.package.outputs.checksum_name }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.metadata.outputs.commit_sha }}
+      - name: Build all release binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --workspace --release --locked
+      - name: Package artifacts
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+          cp target/release/fpgad dist/
+          cp target/release/fpgad_cli dist/
+          chmod +x dist/fpgad dist/fpgad_cli
+
+          ARCHIVE_NAME="fpgad-${{ needs.metadata.outputs.version }}-linux-amd64.tar.gz"
+          CHECKSUM_NAME="${ARCHIVE_NAME}.sha256"
+
+          tar -czf "${ARCHIVE_NAME}" -C dist fpgad fpgad_cli
+          sha256sum "${ARCHIVE_NAME}" > "${CHECKSUM_NAME}"
+
+          {
+            echo "archive_name=${ARCHIVE_NAME}"
+            echo "checksum_name=${CHECKSUM_NAME}"
+          } >> "${GITHUB_OUTPUT}"
+      - name: Upload release assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-assets
+          path: |
+            ${{ steps.package.outputs.archive_name }}
+            ${{ steps.package.outputs.checksum_name }}
+  cargo-publish:
+    name: Publish crates to crates.io
+    needs: metadata
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/cargo-publish.yml
+    with:
+      version: ${{ needs.metadata.outputs.version }}
+      commit_sha: ${{ needs.metadata.outputs.commit_sha }}
+      mode: publish
+  github-release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    needs:
+      - metadata
+      - build
+      - cargo-publish
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v8
+        with:
+          name: release-assets
+          path: .
+      - name: Create GitHub release with gh CLI
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          ARCHIVE="${{ needs.build.outputs.archive_name }}"
+          CHECKSUM="${{ needs.build.outputs.checksum_name }}"
+
+          for asset in "${ARCHIVE}" "${CHECKSUM}"; do
+            if [[ ! -f "${asset}" ]]; then
+              echo "::error::Release asset '${asset}' not found."
+              exit 1
+            fi
+          done
+
+          gh release create "${{ needs.metadata.outputs.tag_name }}" \
+            "${ARCHIVE}" \
+            "${CHECKSUM}" \
+            --target "${{ needs.metadata.outputs.commit_sha }}" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.]+)?$ ]]; then
-            echo "::error::Version must be semver-like (example: 0.1.1 or 0.1.1-rc.1)."
-            exit 1
-          fi
-
           if ! git cat-file -e "${COMMIT_SHA}^{commit}"; then
             echo "::error::Commit '${COMMIT_SHA}' does not exist in this repository."
             exit 1
@@ -57,28 +52,7 @@ jobs:
             fi
           fi
 
-          WORKSPACE_VERSION="$({
-            git show "${COMMIT_SHA}:Cargo.toml" | awk '
-              /^\[workspace\.package\]/ { in_section=1; next }
-              in_section && /^\[/ { in_section=0 }
-              in_section && /^version[[:space:]]*=/ {
-                gsub(/.*"/, "", $0)
-                gsub(/".*/, "", $0)
-                print $0
-                exit
-              }
-            '
-          })"
-
-          if [[ -z "${WORKSPACE_VERSION}" ]]; then
-            echo "::error::Could not read [workspace.package].version from Cargo.toml at ${COMMIT_SHA}."
-            exit 1
-          fi
-
-          if [[ "${WORKSPACE_VERSION}" != "${VERSION}" ]]; then
-            echo "::error::Requested version '${VERSION}' does not match Cargo.toml version '${WORKSPACE_VERSION}' at ${COMMIT_SHA}."
-            exit 1
-          fi
+          python scripts/ci/check_version_bump.py validate --expected-version "${VERSION}" --ref "${COMMIT_SHA}"
 
           {
             echo "tag_name=${TAG_NAME}"
@@ -87,7 +61,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
   build:
     name: Build release artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: metadata
     outputs:
       archive_name: ${{ steps.package.outputs.archive_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
       tag_name: ${{ steps.meta.outputs.tag_name }}
       version: ${{ steps.meta.outputs.version }}
       commit_sha: ${{ steps.meta.outputs.commit_sha }}
-      is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -61,17 +60,10 @@ jobs:
 
           python scripts/ci/check_version_bump.py validate --expected-version "${VERSION}" --ref "${COMMIT_SHA}"
 
-          LOWER_VERSION="${VERSION,,}"
-          IS_PRERELEASE="false"
-          if [[ "${LOWER_VERSION}" =~ (alpha|beta|rc|pre|dev|exp|experimental|nightly) ]]; then
-            IS_PRERELEASE="true"
-          fi
-
           {
             echo "tag_name=${TAG_NAME}"
             echo "version=${VERSION}"
             echo "commit_sha=${COMMIT_SHA}"
-            echo "is_prerelease=${IS_PRERELEASE}"
           } >> "${GITHUB_OUTPUT}"
   build:
     name: Build release artifacts
@@ -80,7 +72,6 @@ jobs:
     outputs:
       archive_name: ${{ steps.package.outputs.archive_name }}
       checksum_name: ${{ steps.package.outputs.checksum_name }}
-      prerelease_crate_bundle: ${{ steps.prerelease_crates.outputs.bundle_name }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -118,24 +109,7 @@ jobs:
           path: |
             ${{ steps.package.outputs.archive_name }}
             ${{ steps.package.outputs.checksum_name }}
-      - name: Package prerelease crate bundle
-        if: ${{ needs.metadata.outputs.is_prerelease == 'true' }}
-        id: prerelease_crates
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          cargo package --workspace --locked
-
-          BUNDLE_NAME="fpgad-${{ needs.metadata.outputs.version }}-experimental-crates.tar.gz"
-          tar -czf "${BUNDLE_NAME}" -C target/package .
-          echo "bundle_name=${BUNDLE_NAME}" >> "${GITHUB_OUTPUT}"
-      - name: Upload prerelease crate bundle
-        if: ${{ needs.metadata.outputs.is_prerelease == 'true' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: prerelease-crates
-          path: ${{ steps.prerelease_crates.outputs.bundle_name }}
+          # prerelease bundle packaging removed — prereleases are no longer supported
   cargo-publish:
     name: Publish crates to crates.io
     needs: metadata
@@ -160,20 +134,12 @@ jobs:
         with:
           name: release-assets
           path: .
-      - name: Download prerelease crate bundle
-        if: ${{ needs.metadata.outputs.is_prerelease == 'true' }}
-        uses: actions/download-artifact@v8
-        with:
-          name: prerelease-crates
-          path: .
       - name: Create GitHub release with gh CLI
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          IS_PRERELEASE="${{ needs.metadata.outputs.is_prerelease }}"
           ARCHIVE="${{ needs.build.outputs.archive_name }}"
           CHECKSUM="${{ needs.build.outputs.checksum_name }}"
           ASSETS=("${ARCHIVE}" "${CHECKSUM}")
@@ -181,16 +147,6 @@ jobs:
             --target "${{ needs.metadata.outputs.commit_sha }}"
             --generate-notes
           )
-
-          if [[ "${IS_PRERELEASE}" == "true" ]]; then
-            EXPERIMENTAL_BUNDLE="${{ needs.build.outputs.prerelease_crate_bundle }}"
-            if [[ -z "${EXPERIMENTAL_BUNDLE}" || ! -f "${EXPERIMENTAL_BUNDLE}" ]]; then
-              echo "::error::Prerelease crate bundle '${EXPERIMENTAL_BUNDLE}' not found."
-              exit 1
-            fi
-            ASSETS+=("${EXPERIMENTAL_BUNDLE}")
-            RELEASE_ARGS+=(--prerelease)
-          fi
 
           for asset in "${ASSETS[@]}"; do
             if [[ ! -f "${asset}" ]]; then

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -24,11 +24,9 @@ If validation passes, the workflow builds in release mode and uploads these asse
 - `fpgad-<version>-linux-amd64.tar.gz` (contains `fpgad` and `fpgad_cli`)
 - `fpgad-<version>-linux-amd64.tar.gz.sha256`
 
-The same workflow also publishes crates to crates.io by default by invoking `.github/workflows/cargo-publish.yml` in `publish` mode, in dependency order:
+The same workflow also publishes workspace crates to crates.io by default by invoking `.github/workflows/cargo-publish.yml` in `publish` mode.
 
-- `fpgad_macros`
-- `fpgad`
-- `fpgad_cli`
+It uses a top-level workspace publish command (`cargo publish --manifest-path Cargo.toml --workspace --locked`).
 
 Publishing uses crates.io Trusted Publishing (OIDC) instead of a long-lived API token.
 
@@ -82,7 +80,7 @@ Inputs:
 
 Behavior:
 
-- Publishes packages in dependency order: `fpgad_macros` -> `fpgad` -> `fpgad_cli`
+- Publishes all workspace crates using `cargo publish --manifest-path Cargo.toml --workspace --locked`
 - Validates that `Cargo.toml` version matches the requested version
 - For `mode=publish`, requires crates.io Trusted Publishing configuration for this workflow file (`cargo-publish.yml`)
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,6 +1,46 @@
 # Publishing Guide for FPGAd
 
-This document explains how to publish the FPGAd packages to crates.io.
+This document explains how to release tagged versions on GitHub and publish the FPGAd packages to crates.io.
+
+## GitHub Release Automation
+
+GitHub releases are handled by `.github/workflows/release.yml`.
+
+### Trigger Modes
+
+1. Push a tag (`v*`) to build and publish a release automatically.
+2. Run the workflow manually (`workflow_dispatch`) with:
+    - `version` (for example `0.1.1`)
+    - `commit_sha` (the exact commit to release)
+
+The release workflow validates that:
+
+- The version is semver-like
+- The commit exists
+- The requested version matches `[workspace.package].version` in `Cargo.toml` at that commit
+
+If validation passes, the workflow builds in release mode and uploads these assets to the GitHub release:
+
+- `fpgad-<version>-linux-amd64.tar.gz` (contains `fpgad` and `fpgad_cli`)
+- `fpgad-<version>-linux-amd64.tar.gz.sha256`
+
+The same workflow also publishes crates to crates.io by default by invoking `.github/workflows/cargo-publish.yml` in `publish` mode, in dependency order:
+
+- `fpgad_macros`
+- `fpgad`
+- `fpgad_cli`
+
+Publishing uses crates.io Trusted Publishing (OIDC) instead of a long-lived API token.
+
+On crates.io, configure Trusted Publishing for this repository and workflow file (`cargo-publish.yml`) before first use.
+
+### Changelog Strategy
+
+This repository currently uses GitHub-generated release notes (`--generate-notes`) as the release changelog.
+
+This approach keeps release notes aligned with merged PRs and labels without requiring a manually maintained `CHANGELOG.md`.
+
+If a manually curated changelog is preferred later, add `CHANGELOG.md` and include an explicit update step in the release checklist.
 
 ## Package Structure
 
@@ -27,8 +67,28 @@ Packages must be published in this order due to dependencies:
 - [ ] All packages compile successfully
 - [ ] All tests pass (CI auto runs on PR)
 - [ ] Documentation is complete
-- [ ] CHANGELOG is up to date
+- [ ] GitHub release notes reviewed (or CHANGELOG updated, if adopted)
 - [ ] Git repository is clean
+
+## Cargo Publish Automation
+
+Cargo publishing is handled by `.github/workflows/cargo-publish.yml` (manual trigger and reusable workflow).
+
+Inputs:
+
+- `version` (for example `0.1.1`)
+- `commit_sha`
+- `mode`: `dry-run` or `publish`
+
+Behavior:
+
+- Publishes packages in dependency order: `fpgad_macros` -> `fpgad` -> `fpgad_cli`
+- Validates that `Cargo.toml` version matches the requested version
+- For `mode=publish`, requires crates.io Trusted Publishing configuration for this workflow file (`cargo-publish.yml`)
+
+Use `mode=dry-run` to validate the publishing flow safely.
+
+Use the manual workflow when you want to validate publish behavior before creating a GitHub release.
 
 ## Publishing Commands
 
@@ -60,6 +120,8 @@ Before publishing, test with dry-run:
 ```bash
 cargo publish --dry-run
 ```
+
+Or use the `cargo-publish.yml` workflow with `mode=dry-run`.
 
 ## Version Updates
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -24,6 +24,10 @@ If validation passes, the workflow builds in release mode and uploads these asse
 - `fpgad-<version>-linux-amd64.tar.gz` (contains `fpgad` and `fpgad_cli`)
 - `fpgad-<version>-linux-amd64.tar.gz.sha256`
 
+If the resolved version contains one of these prerelease keywords (`alpha`, `beta`, `rc`, `pre`, `dev`, `exp`, `experimental`, `nightly`), the workflow creates a GitHub prerelease and also uploads:
+
+- `fpgad-<version>-experimental-crates.tar.gz` (workspace `.crate` bundles produced by `cargo package --workspace --locked`)
+
 The same workflow also publishes workspace crates to crates.io by default by invoking `.github/workflows/cargo-publish.yml` in `publish` mode.
 
 It uses a top-level workspace publish command (`cargo publish --manifest-path Cargo.toml --workspace --locked`).

--- a/scripts/ci/check_version_bump.py
+++ b/scripts/ci/check_version_bump.py
@@ -12,18 +12,23 @@
 # You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
 """
-Check if version was bumped when Rust source files are modified.
+Version policy checks for Cargo.toml.
 
-This script compares the version in Cargo.toml between the base branch
-and the current branch, ensuring proper semver versioning when Rust
-source files have been modified.
+Supported modes:
+1) bump (default):
+    Ensure [workspace.package].version increased compared to the base branch.
+2) validate:
+    Validate a target version and enforce lockstep between
+    [workspace.package].version and [workspace.dependencies].fpgad_macros.version.
 """
 
+import argparse
 import os
+import re
 import subprocess
 import sys
-import re
 from pathlib import Path
+
 import tomllib
 
 
@@ -54,20 +59,49 @@ def get_cargo_toml_content(ref: str | None = None) -> str:
         return cargo_path.read_text()
 
 
-def parse_version_from_toml(toml_content: str) -> str:
-    """Parse version from Cargo.toml content."""
+def parse_toml(toml_content: str) -> dict:
+    """Parse Cargo.toml content into a dictionary."""
     try:
-        data = tomllib.loads(toml_content)
-        version = data.get("workspace", {}).get("package", {}).get("version")
-
-        if not version:
-            print("::error::Could not find version in [workspace.package] section")
-            sys.exit(1)
-
-        return version
+        return tomllib.loads(toml_content)
     except Exception as e:
         print(f"::error::Failed to parse TOML: {e}")
         sys.exit(1)
+
+
+def get_workspace_version(toml_data: dict) -> str:
+    """Return [workspace.package].version."""
+    version = toml_data.get("workspace", {}).get("package", {}).get("version")
+    if not version:
+        print("::error::Could not find version in [workspace.package] section")
+        sys.exit(1)
+    return version
+
+
+def get_fpgad_macros_dependency_version(toml_data: dict) -> str:
+    """Return [workspace.dependencies].fpgad_macros.version."""
+    dependency = (
+        toml_data.get("workspace", {}).get("dependencies", {}).get("fpgad_macros")
+    )
+
+    if not dependency:
+        print("::error::Could not find [workspace.dependencies].fpgad_macros")
+        sys.exit(1)
+
+    if isinstance(dependency, str):
+        # String-form dependency declaration, e.g. fpgad_macros = "0.1.1"
+        return dependency
+
+    if isinstance(dependency, dict):
+        version = dependency.get("version")
+        if not version:
+            print(
+                "::error::Could not find version in [workspace.dependencies].fpgad_macros"
+            )
+            sys.exit(1)
+        return version
+
+    print("::error::Invalid format for [workspace.dependencies].fpgad_macros")
+    sys.exit(1)
 
 
 def parse_semver(version: str) -> tuple[int, int, int]:
@@ -105,20 +139,81 @@ def compare_versions(old_version: str, new_version: str) -> bool:
     return False
 
 
-def main():
+def enforce_version_lock(
+    workspace_version: str, macros_dependency_version: str
+) -> None:
+    """Ensure workspace and fpgad_macros dependency versions stay in lockstep."""
+    if workspace_version != macros_dependency_version:
+        print(
+            "::error::Version lock mismatch!%0A"
+            f"[workspace.package].version: {workspace_version}%0A"
+            f"[workspace.dependencies].fpgad_macros.version: {macros_dependency_version}%0A"
+            "%0A"
+            "These versions must always match.%0A"
+            "Please update root Cargo.toml so both versions are identical.%0A"
+        )
+        sys.exit(1)
+
+
+def validate_mode(expected_version: str, ref: str | None) -> None:
+    """Validate expected version and lockstep constraints."""
+    toml_content = get_cargo_toml_content(ref)
+    toml_data = parse_toml(toml_content)
+
+    workspace_version = get_workspace_version(toml_data)
+    macros_dependency_version = get_fpgad_macros_dependency_version(toml_data)
+
+    # Validate both strings are semver-like and lockstep.
+    parse_semver(workspace_version)
+    parse_semver(macros_dependency_version)
+
+    enforce_version_lock(workspace_version, macros_dependency_version)
+
+    if workspace_version != expected_version:
+        print(
+            "::error::Requested version does not match Cargo.toml.%0A"
+            f"Requested version: {expected_version}%0A"
+            f"[workspace.package].version: {workspace_version}%0A"
+        )
+        sys.exit(1)
+
+    print(
+        "✅ Version validation passed: "
+        f"requested={expected_version}, workspace={workspace_version}, "
+        f"fpgad_macros dependency={macros_dependency_version}"
+    )
+
+
+def bump_mode() -> None:
+    """Ensure workspace version was bumped when Rust sources changed."""
     # Get base ref from environment or use 'main' as default
     base_ref = os.environ.get("GITHUB_BASE_REF", "main")
 
     print("::group::extract version numbers")
     # Get versions
     old_toml = get_cargo_toml_content(f"origin/{base_ref}")
-    old_version = parse_version_from_toml(old_toml)
+    old_data = parse_toml(old_toml)
+    old_version = get_workspace_version(old_data)
 
     new_toml = get_cargo_toml_content()
-    new_version = parse_version_from_toml(new_toml)
+    new_data = parse_toml(new_toml)
+    new_version = get_workspace_version(new_data)
+    new_macros_dependency_version = get_fpgad_macros_dependency_version(new_data)
 
     print(f"Old version: {old_version}")
     print(f"New version: {new_version}")
+    print(
+        "New [workspace.dependencies].fpgad_macros.version: "
+        f"{new_macros_dependency_version}"
+    )
+    print("::endgroup::")
+
+    print("::group::validate version lock")
+    enforce_version_lock(new_version, new_macros_dependency_version)
+    print(
+        "✅ Version lock is valid: "
+        f"workspace={new_version}, fpgad_macros dependency={new_macros_dependency_version}"
+    )
     print("::endgroup::")
 
     print("::group::compare versions using semver")
@@ -138,9 +233,43 @@ def main():
         print(error_msg)
         print("::endgroup::")  # necessary to avoid never-ending group
         sys.exit(1)
-    else:
-        print(f"✅ Version was properly increased: {old_version} → {new_version}")
-        print("::endgroup::")
+
+    print(f"✅ Version was properly increased: {old_version} → {new_version}")
+    print("::endgroup::")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments while preserving backward compatibility."""
+    parser = argparse.ArgumentParser(description="Cargo.toml version policy checks")
+    subparsers = parser.add_subparsers(dest="command")
+
+    validate_parser = subparsers.add_parser(
+        "validate",
+        help="validate requested version and enforce workspace/fpgad_macros lockstep",
+    )
+    validate_parser.add_argument(
+        "--expected-version",
+        required=True,
+        help="expected release version (for example: 0.1.1)",
+    )
+    validate_parser.add_argument(
+        "--ref",
+        required=False,
+        help="optional git ref to read Cargo.toml from (for example commit SHA)",
+    )
+
+    # No-argument invocation remains the default bump check.
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if args.command == "validate":
+        validate_mode(args.expected_version, args.ref)
+        return
+
+    bump_mode()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduce new GitHub Actions workflows to automate publishing crates to crates.io using trusted publishing, and to build and package release artifacts for tagged versions.