### PR TITLE
tests: workaround - make the first test to run in snap testing to be a universal test

### DIFF
--- a/tests/snap_testing/test_default/test_cli_options.py
+++ b/tests/snap_testing/test_default/test_cli_options.py
@@ -9,11 +9,6 @@ from common.helpers import is_dfx_mgr_available
 class TestCLIOptions(FPGATestBase):
     """Test CLI options like --device, --platform, and --name."""
 
-    def test_status_with_device_option(self):
-        """Test status command with explicit --device option."""
-        proc = self.run_fpgad(["--device", "fpga0", "status"])
-        self.assert_proc_succeeds(proc)
-
     def test_status_with_platform_option_universal(self):
         """Test status command with explicit --platform option set to `universal`."""
         proc = self.run_fpgad(["--platform", "universal", "status"])
@@ -30,3 +25,8 @@ class TestCLIOptions(FPGATestBase):
         self.assert_in_proc_out(
             "#  Accel_type  user_load_type user_load_region Base", proc
         )
+
+    def test_status_with_specific_device_option(self):
+        """Test status command with explicit --device option (runs last to allow daemon startup)."""
+        proc = self.run_fpgad(["--device", "fpga0", "status"])
+        self.assert_proc_succeeds(proc)


### PR DESCRIPTION
workaround for #189 which just (hopefully) makes the tests more stable <- this needs to be fixed robustly.

Just renames test_status_with_device_option to test_status_with_specific_device_option.

This is works since tests are discovered alphabetically. This is necessary because the dfx-mgr test being first means that the attempt to call dfx-mgr-client happens before dfx-mgrd is up and running. There should be a proper way to wait for come-up in dfx-mgr softener

This test name must be alphabetically after the universal test to ensure that the first test doesn't require dfx-mgr to be up and running which takes a few ms.