### PR TITLE
root: snapcraft - add dfx-mgr socket hook to restart fpgad on socket connection

### DIFF
--- a/snap/hooks/connect-plug-dfx-mgr-socket
+++ b/snap/hooks/connect-plug-dfx-mgr-socket
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Log the connection event
+echo "dfx-mgr-socket plug connected, restarting fpgad daemon..."
+
+# Restart the fpgad daemon to pick up the dfx-mgr socket
+snapctl restart "$SNAP_INSTANCE_NAME.daemon"
+
+echo "fpgad daemon restart triggered successfully"


### PR DESCRIPTION
This restarts the softener thread so that dfx-mgr is enabled after install