### PR TITLE
softeners: dfx-mgr - share logic to find dfx-mgr-client binary between dbus method and run_dfx_mgr

### DIFF
--- a/daemon/src/comm/dbus/control_interface.rs
+++ b/daemon/src/comm/dbus/control_interface.rs
@@ -342,7 +342,7 @@ impl ControlInterface {
         {
             let args: Vec<&str> = cmd_string.split_whitespace().collect();
 
-            return match run_dfx_mgr(&args) {
+            match run_dfx_mgr(&args) {
                 Ok(output) => {
                     info!("dfx-mgr command ran successfully!");
                     Ok(output)
@@ -351,7 +351,7 @@ impl ControlInterface {
                     info!("dfx-mgr command failed: {}", e);
                     Err(e.into())
                 }
-            };
+            }
         }
 
         #[cfg(not(feature = "xilinx-dfx-mgr"))]

--- a/daemon/src/comm/dbus/control_interface.rs
+++ b/daemon/src/comm/dbus/control_interface.rs
@@ -338,10 +338,11 @@ impl ControlInterface {
     /// let result = control_interface.dfx_mgr("-load 0 my_design").await?;
     /// ```
     async fn dfx_mgr(&self, cmd_string: &str) -> Result<String, fdo::Error> {
-        if cfg!(feature = "xilinx-dfx-mgr") {
+        #[cfg(feature = "xilinx-dfx-mgr")]
+        {
             let args: Vec<&str> = cmd_string.split_whitespace().collect();
 
-            match run_dfx_mgr(&args) {
+            return match run_dfx_mgr(&args) {
                 Ok(output) => {
                     info!("dfx-mgr command ran successfully!");
                     Ok(output)
@@ -350,8 +351,12 @@ impl ControlInterface {
                     info!("dfx-mgr command failed: {}", e);
                     Err(e.into())
                 }
-            }
-        } else {
+            };
+        }
+
+        #[cfg(not(feature = "xilinx-dfx-mgr"))]
+        {
+            let _ = cmd_string;
             use crate::error::FpgadError;
             Err(FpgadError::Feature(
                 "Cannot use DfxMgr method - FPGAd was compiled without xilinx-dfx-mgr feature"

--- a/daemon/src/comm/dbus/control_interface.rs
+++ b/daemon/src/comm/dbus/control_interface.rs
@@ -17,6 +17,7 @@
 //!
 
 use crate::comm::dbus::validate_device_handle;
+use crate::error::FpgadError;
 use crate::platforms::platform::{platform_for_known_platform, platform_from_compat_or_device};
 use crate::platforms::universal::universal_write_handler;
 #[cfg(feature = "xilinx-dfx-mgr")]
@@ -340,9 +341,18 @@ impl ControlInterface {
     async fn dfx_mgr(&self, cmd_string: &str) -> Result<String, fdo::Error> {
         #[cfg(feature = "xilinx-dfx-mgr")]
         {
-            let args: Vec<&str> = cmd_string.split_whitespace().collect();
+            use tokio::task;
+            // Avoid borrowing from `cmd_string` across an await point by creating
+            // owned Strings and moving them into the blocking task.
+            let cmd_owned = cmd_string.to_string();
+            let res = task::spawn_blocking(move || {
+                let args: Vec<&str> = cmd_owned.split_whitespace().collect();
+                run_dfx_mgr(&args)
+            })
+            .await
+            .map_err(|e| FpgadError::Internal(format!("dfx-mgr-client subprocess failed: {e}")))?;
 
-            match run_dfx_mgr(&args) {
+            match res {
                 Ok(output) => {
                     info!("dfx-mgr command ran successfully!");
                     Ok(output)
@@ -357,7 +367,6 @@ impl ControlInterface {
         #[cfg(not(feature = "xilinx-dfx-mgr"))]
         {
             let _ = cmd_string;
-            use crate::error::FpgadError;
             Err(FpgadError::Feature(
                 "Cannot use DfxMgr method - FPGAd was compiled without xilinx-dfx-mgr feature"
                     .into(),

--- a/daemon/src/comm/dbus/control_interface.rs
+++ b/daemon/src/comm/dbus/control_interface.rs
@@ -17,15 +17,13 @@
 //!
 
 use crate::comm::dbus::validate_device_handle;
-use crate::error::map_error_io_to_fdo;
 use crate::platforms::platform::{platform_for_known_platform, platform_from_compat_or_device};
 use crate::platforms::universal::universal_write_handler;
-use crate::softeners::error::FpgadSoftenerError;
+#[cfg(feature = "xilinx-dfx-mgr")]
+use crate::softeners::xilinx_dfx_mgr::xilinx_dfx_mgr_helpers::run_dfx_mgr;
 use log::{info, trace};
-use std::env;
 use std::path::Path;
 use std::sync::Arc;
-use tokio::process::Command;
 use tokio::sync::{Mutex, MutexGuard, OnceCell};
 use zbus::{fdo, interface};
 
@@ -326,7 +324,7 @@ impl ControlInterface {
     ///   (e.g. `"-listPackage"` or `"-b my_bitstream.bit.bin -o my_overlay.dtbo"`)
     ///
     /// # Returns: `Result<String, fdo::Error>`
-    /// * `Ok(String)` – Exit status, stdout, and stderr from `dfx-mgr-client` on success
+    /// * `Ok(String)` – stdout from `dfx-mgr-client` on success
     /// * `Err(fdo::Error)` – If `dfx-mgr-client` is not found, the process fails, or
     ///   the `xilinx-dfx-mgr` feature was not compiled in
     ///
@@ -341,51 +339,16 @@ impl ControlInterface {
     /// ```
     async fn dfx_mgr(&self, cmd_string: &str) -> Result<String, fdo::Error> {
         if cfg!(feature = "xilinx-dfx-mgr") {
-            let snap_env = env::var("SNAP").unwrap_or("".to_string());
+            let args: Vec<&str> = cmd_string.split_whitespace().collect();
 
-            let dfx_mgr_client_path = format!("{}/usr/bin/dfx-mgr-client", snap_env);
-
-            // Check if dfx-mgr-client exists
-            if !Path::new(&dfx_mgr_client_path).exists() {
-                return Err(FpgadSoftenerError::DfxMgr(format!(
-                    "dfx-mgr-client not detected.\n\
-                    If using snap, please install the dfx-mgr component with \n\
-                    `[sudo] snap install fpgad+dfx-mgr [options]` \n\
-                    otherwise ensure that dfx-mgr-client exists at `{dfx_mgr_client_path}`"
-                ))
-                .into());
-            }
-
-            let output = Command::new(&dfx_mgr_client_path)
-                .args(cmd_string.split_whitespace())
-                .output()
-                .await
-                .map_err(|e| {
-                    map_error_io_to_fdo("dfx-mgr-client call failed to produce any output", e)
-                })?;
-
-            // Exit status
-            match output.status.success() {
-                true => {
-                    info!("Command ran successfully!");
-                    Ok(format!(
-                        "dfx-mgr called with args {}.\nExit status: {}\nStdout:\n{}\nStderr:\n{}",
-                        cmd_string,
-                        output.status,
-                        String::from_utf8_lossy(&output.stdout),
-                        String::from_utf8_lossy(&output.stderr),
-                    ))
+            match run_dfx_mgr(&args) {
+                Ok(output) => {
+                    info!("dfx-mgr command ran successfully!");
+                    Ok(output)
                 }
-                false => {
-                    info!("Command failed with code: {:#?}", output.status.code());
-                    Err(FpgadSoftenerError::DfxMgr(format!(
-                        "dfx-mgr called with args {}.\nExit status: {}\nStdout:\n{}\nStderr:\n{}",
-                        cmd_string,
-                        output.status,
-                        String::from_utf8_lossy(&output.stdout),
-                        String::from_utf8_lossy(&output.stderr),
-                    ))
-                    .into())
+                Err(e) => {
+                    info!("dfx-mgr command failed: {}", e);
+                    Err(e.into())
                 }
             }
         } else {

--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -131,17 +131,3 @@ impl From<FpgadError> for fdo::Error {
         }
     }
 }
-
-///  Converter for tokio::io::Error into zbus::fdo::Error types, with added "custom_msg" in order
-///  to provide additional context.
-///  This allows for "?" on e.g., tokio::io::Command calls
-///
-/// # Arguments
-///
-/// * `custom_msg`: String to prepend the error - use to add context e.g. "failed when calling nproc"
-/// * `err`: the tokio::io::error from the failing function
-///
-/// returns: zbus::fdo::Error type suitable for dbus transmission
-pub(crate) fn map_error_io_to_fdo(custom_msg: &str, err: impl std::fmt::Display) -> fdo::Error {
-    fdo::Error::Failed(format!("{custom_msg}:\n{err}"))
-}

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -11,7 +11,9 @@
 // You should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/.
 
 use fpgad::comm::dbus::{control_interface::ControlInterface, status_interface::StatusInterface};
-use fpgad::{register_platforms, softeners};
+use fpgad::register_platforms;
+#[cfg(feature = "softeners")]
+use fpgad::softeners;
 use log::info;
 use std::error::Error;
 use std::future::pending;

--- a/daemon/src/softeners/xilinx_dfx_mgr.rs
+++ b/daemon/src/softeners/xilinx_dfx_mgr.rs
@@ -55,7 +55,6 @@
 //! # }
 //! ```
 
-use std::env;
 use std::path::Path;
 use std::sync::OnceLock;
 
@@ -65,6 +64,7 @@ use crate::softeners::error::FpgadSoftenerError;
 use fpgad_macros::platform;
 use log::trace;
 use xilinx_dfx_mgr_fpga::XilinxDfxMgrFPGA;
+use xilinx_dfx_mgr_helpers::run_dfx_mgr;
 use xilinx_dfx_mgr_overlay_handler::XilinxDfxMgrOverlayHandler;
 
 // Marked as public so that the members are published in docs
@@ -216,42 +216,4 @@ pub fn load_overlay(bitstream_path: &Path, dtbo_path: &Path) -> Result<String, F
     })?;
 
     run_dfx_mgr(&["-o", dtbo_str, "-b", bitstream_str])
-}
-
-/// Helper to run the dfx-mgr-client binary with arguments
-fn run_dfx_mgr(args: &[&str]) -> Result<String, FpgadSoftenerError> {
-    let prefix = if let Ok(snap_env) = env::var("SNAP_COMPONENTS") {
-        snap_env + "/dfx-mgr"
-    } else {
-        "".to_string()
-    };
-
-    let dfx_mgr_client_path = format!("{}/usr/bin/dfx-mgr-client", prefix);
-
-    // Check if dfx-mgr-client exists before trying to run it
-    if !Path::new(&dfx_mgr_client_path).exists() {
-        return Err(FpgadSoftenerError::DfxMgr(format!(
-            "dfx-mgr-client not found at '{}'. Install the dfx-mgr component with: snap install fpgad+dfx-mgr.comp",
-            dfx_mgr_client_path
-        )));
-    }
-
-    trace!("Calling dfx-mgr with args {:#?}", args);
-    let output = std::process::Command::new(&dfx_mgr_client_path)
-        .args(args)
-        .output()
-        .map_err(|e| {
-            FpgadSoftenerError::DfxMgr(format!("dfx-mgr-client failed to produce output:\n{e}"))
-        })?;
-    if output.status.success() {
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
-    } else {
-        // output.status usually looks like `exit status: 255`
-        Err(FpgadSoftenerError::DfxMgr(format!(
-            "dfx-mgr-client failed.\n{}\nStdout:\n{:?}\nStderr:\n{:?}",
-            output.status,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        )))
-    }
 }

--- a/daemon/src/softeners/xilinx_dfx_mgr/xilinx_dfx_mgr_helpers.rs
+++ b/daemon/src/softeners/xilinx_dfx_mgr/xilinx_dfx_mgr_helpers.rs
@@ -17,6 +17,8 @@
 //!
 //! # Key Functions
 //!
+//! - [`get_dfx_mgr_client_path`] - Locates and validates the dfx-mgr-client binary path
+//! - [`run_dfx_mgr`] - Executes dfx-mgr-client synchronously with given arguments
 //! - [`extract_firmware_name`] - Parses .dtbo files to extract the firmware-name property
 //!
 //! # Device Tree Parsing
@@ -40,8 +42,109 @@
 use crate::error::FpgadError;
 use crate::softeners::error::FpgadSoftenerError;
 use log::trace;
+use std::env;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
+
+/// Get the path to the dfx-mgr-client binary and verify it exists.
+///
+/// Checks for dfx-mgr-client in the following order:
+/// 1. In snap component: `$SNAP_COMPONENTS/dfx-mgr/usr/bin/dfx-mgr-client`
+/// 2. In system files: `/usr/bin/dfx-mgr-client` when `$SNAP_COMPONENTS` is not set
+///
+/// # Returns
+/// * `Ok(String)` - The path to dfx-mgr-client if it exists
+/// * `Err(FpgadSoftenerError)` - If dfx-mgr-client cannot be found or doesn't exist
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # use daemon::softeners::xilinx_dfx_mgr::xilinx_dfx_mgr_helpers::get_dfx_mgr_client_path;
+/// # fn example() -> Result<(), daemon::softeners::error::FpgadSoftenerError> {
+/// let path = get_dfx_mgr_client_path()?;
+/// println!("dfx-mgr-client is at: {}", path);
+/// # Ok(())
+/// # }
+/// ```
+pub fn get_dfx_mgr_client_path() -> Result<String, FpgadSoftenerError> {
+    // Check for dfx-mgr-client in snap component first, then fall back to system files
+    let dfx_mgr_client_path = if let Ok(snap_components) = env::var("SNAP_COMPONENTS") {
+        let path = format!("{}/dfx-mgr/usr/bin/dfx-mgr-client", snap_components);
+        if !Path::new(&path).exists() {
+            return Err(FpgadSoftenerError::DfxMgr(format!(
+                "dfx-mgr-client not found at '{path}'.\n\n\
+            To enable Xilinx DFX Manager support, install the dfx-mgr component:\n\n\
+                `sudo snap install fpgad+dfx-mgr.comp --dangerous`\n\n\
+            Or run the CLI using the `universal` platform (no dfx-mgr required):\n\n\
+                `fpgad --platform=universal <command>`\n\n\
+            If you are calling the daemon over DBus manually \n\n \
+                set the `platform_string` to `universal` instead."
+            )));
+        }
+        path
+    } else {
+        let path = String::from("/usr/bin/dfx-mgr-client");
+        if !Path::new(&path).exists() {
+            return Err(FpgadSoftenerError::DfxMgr(format!(
+                "dfx-mgr-client not found on system at '{path}'.\n\n\
+            To enable Xilinx DFX Manager support, install the dfx-mgr binaries e.g.\n\n\
+                `sudo apt install dfx-mgr`\n\n\
+            Or run the CLI using the `universal` platform (no dfx-mgr required):\n\n\
+                `fpgad --platform=universal <command>`\n\n\
+            If you are calling the daemon over DBus manually \n\n \
+                set the `platform_string` to `universal` instead."
+            )));
+        }
+        path
+    };
+
+    Ok(dfx_mgr_client_path)
+}
+
+/// Run dfx-mgr-client with the given arguments (synchronous version).
+///
+/// # Arguments
+///
+/// * `args` - Command line arguments to pass to dfx-mgr-client
+///
+/// # Returns
+/// * `Ok(String)` - stdout from dfx-mgr-client on success
+/// * `Err(FpgadSoftenerError)` - Formatted stdout, stderr and exit status from dfx-mgr-client if dfx-mgr-client
+///   execution fails of string explaining that dfx-mgr-client cannot be found
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # use daemon::softeners::xilinx_dfx_mgr::xilinx_dfx_mgr_helpers::run_dfx_mgr;
+/// # fn example() -> Result<(), daemon::softeners::error::FpgadSoftenerError> {
+/// let output = run_dfx_mgr(&["-listPackage"])?;
+/// println!("Packages: {}", output);
+/// # Ok(())
+/// # }
+/// ```
+pub fn run_dfx_mgr(args: &[&str]) -> Result<String, FpgadSoftenerError> {
+    let dfx_mgr_client_path = get_dfx_mgr_client_path()?;
+
+    trace!("Calling dfx-mgr-client with args {:#?}", args);
+    let output = Command::new(&dfx_mgr_client_path)
+        .args(args)
+        .output()
+        .map_err(|e| {
+            FpgadSoftenerError::DfxMgr(format!("dfx-mgr-client failed to produce output:\n{e}"))
+        })?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        Err(FpgadSoftenerError::DfxMgr(format!(
+            "dfx-mgr-client failed.\n{}\nStdout:\n{:?}\nStderr:\n{:?}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )))
+    }
+}
 
 /// Extract the firmware-name property from a device tree overlay (.dtbo) file
 ///


### PR DESCRIPTION

both dfx_mgr dbus method and run_dfx_mgr function inside the softener now share the path resolution to find dfx-mgr-client to reduce maintenance burden run_dfx_mgr called from within the dbus method