### PR TITLE
root: snapcraft.yaml - provide fpgad_cli via content interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
 
 [[package]]
 name = "fpgad"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "env_logger",
  "fdt",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "fpgad_cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "clap_complete",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "fpgad_macros"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["daemon", "cli", "fpgad_macros"]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://github.com/canonical/fpgad"
@@ -11,7 +11,7 @@ repository = "https://github.com/canonical/fpgad"
 authors = ["Talha Can Havadar <talha.can.havadar@canonical.com>", "Artie Poole <stuart.poole@canonical.com>"]
 
 [workspace.dependencies]
-fpgad_macros = { version = "0.4.2", path = "fpgad_macros" }
+fpgad_macros = { version = "0.4.3", path = "fpgad_macros" }
 
 [profile.release]
 opt-level = "z"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ appropriate drivers are loaded.
 
 ![anticipated_architecture.png](docs/assets/anticipated_architecture.png)
 
+# Documentation
+
+- [`cli/README.md`](cli/README.md) — `fpgad_cli` command usage and examples.
+- [`daemon/README.md`](daemon/README.md) — `fpgad` daemon D-Bus API (Control/Status interfaces) and running as a snap.
+- [`snap/README.md`](snap/README.md) — on creating provider snaps using `fpgad_cli` (content interface + wrapper script recommended, to keep the CLI and daemon versions in sync; or `stage-snaps` to pin the binary at build time).
+- [`docs/code_coverage.md`](docs/code_coverage.md) — gathering code coverage for the daemon.
+- [`PUBLISHING.md`](PUBLISHING.md) — release process for maintainers (GitHub releases, crates.io).
+- Cargo docs: [docs.rs/fpgad](https://docs.rs/fpgad), [docs.rs/fpgad_cli](https://docs.rs/fpgad_cli), [docs.rs/fpgad_macros](https://docs.rs/fpgad_macros).
+
 # Building and running from source
 
 From a fresh install, you must install build-essential, rustup (includes cargo) and pull the source from the repo then

--- a/daemon/src/platforms/xilinx_sys.rs
+++ b/daemon/src/platforms/xilinx_sys.rs
@@ -609,8 +609,9 @@ fn set_flags(fpga: &XilinxSysFPGA, new_flags: u32) -> Result<String, FpgadError>
         return Err(e);
     }
 
-    match fpga.state() {
-        Ok(state) => match state.as_str() {
+    {
+        let state = fpga.state()?;
+        match state.as_str() {
             "operating" => {
                 info!(
                     "{}'s state is 'operating' after writing flags.",
@@ -623,8 +624,7 @@ fn set_flags(fpga: &XilinxSysFPGA, new_flags: u32) -> Result<String, FpgadError>
                     device_handle, state
                 );
             }
-        },
-        Err(e) => return Err(e),
+        }
     };
 
     let returned_flags = flags(fpga)?;

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,145 @@
+# Consuming `fpgad_cli` from another snap
+
+This document is for authors of provider snaps intending to use FPGAd to control the FPGA subsystems on Linux, such as Ubuntu Core.
+
+For `fpgad_cli`'s own command usage, see [`cli/README.md`](../cli/README.md).
+For the canonical definitions of the interfaces mentioned below, see [`snapcraft.yaml`](snapcraft.yaml).
+
+There are two supported approaches:
+
+1. [Content interface + wrapper script](#option-1-content-interface--wrapper-script-recommended) (recommended) — stage [`wrapper/fpgad_cli_wrapper.py`](wrapper/fpgad_cli_wrapper.py) and connect to `fpgad`'s `fpgad-cli-app` content slot at runtime.
+   This keeps `fpgad_cli` in sync with whichever `fpgad` daemon is installed, avoiding version drift between the CLI and daemon.
+2. [`stage-snaps`](#option-2-stage-snaps-direct-binary-staging) — pull the `fpgad_cli` binary directly into your snap at build time.
+
+Pick whichever fits your update/versioning requirements — see the [comparison](#comparison) at the end.
+
+## Option 1: content interface + wrapper script (recommended)
+
+Instead of copying the CLI binary at build time, you can stage the small [`fpgad_cli_wrapper.py`](wrapper/fpgad_cli_wrapper.py) script from the published `fpgad` snap and connect to `fpgad`'s `fpgad-cli-app` content slot (which exposes `$SNAP/cli` from the installed `fpgad` snap, see [`snapcraft.yaml:55-60`](snapcraft.yaml)) at runtime.
+This way your snap always calls whichever `fpgad_cli` is currently installed and connected, with no rebuild required when `fpgad` updates.
+
+**This is the recommended approach.**
+Because `fpgad_cli` and the `fpgad` daemon are versioned and released together, staging the binary yourself (Option 2) risks a `fpgad_cli` build that is out of sync with the `fpgad` daemon actually running on the user's system (e.g. after the user refreshes `fpgad` but not `provider-example`).
+Connecting to the content interface at runtime guarantees the CLI and daemon versions always match.
+
+Below is a real, working example (trimmed to just the parts relevant to `fpgad_cli`.
+
+```yaml
+name: provider-example
+# ...
+
+plugs:
+  fpgad-dbus:
+    interface: dbus
+    bus: system
+    name: com.canonical.fpgad
+  fpgad-cli-app:
+    interface: content
+    content: fpgad-cli-content
+    target: $SNAP/fpgad
+
+apps:
+  init:
+    command: wrapper/fpgad_cli_wrapper.py...
+    plugs:
+      - fpgad-dbus
+
+parts:
+  cli-wrapper:
+    plugin: nil
+    stage-snaps:
+      - fpgad/latest/<edge|beta|candidate|stable>
+    stage:
+      - wrapper/fpgad_cli_wrapper.py
+```
+
+Note that the `fpgad-dbus` plug will need to be connected to each app calling `cli/fpgad_cli_wrapper.py`.
+
+Pull the wrapper from whichever `fpgad` track/risk your snap targets .
+Pick the channel that matches the `fpgad` compatibility you need, e.g.`fpgad/latest/stable`.
+See the following subsection for instructions for staging from GitHub if you prefer:
+
+```yaml
+parts:
+  cli_wrapper:
+    plugin: dump
+    source: https://github.com/canonical/fpgad.git
+    source-subdir: snap/wrapper
+    organize:
+      fpgad_cli_wrapper.py: cli/fpgad_cli_wrapper.py
+```
+
+At runtime, the user needs to install `fpgad` and connect both the content interface and the D-Bus interface (since `fpgad_cli` talks to the `fpgad` daemon over D-Bus):
+
+```shell
+sudo snap install fpgad
+sudo snap install fpgad+<component_name>   # if you require an optional component, e.g. dfx-mgr
+sudo snap connect provider-example:fpgad-cli-app fpgad:fpgad-cli-content
+sudo snap connect provider-example:fpgad-dbus fpgad:daemon-dbus
+```
+
+This matches the guidance printed by the wrapper script itself if it can't find `fpgad_cli` at runtime (see [`wrapper/fpgad_cli_wrapper.py`](wrapper/fpgad_cli_wrapper.py)).
+
+Notes:
+
+- The wrapper always invokes whatever `fpgad_cli` binary is exposed by the currently installed and connected `fpgad` snap, so it tracks `fpgad` updates automatically — no rebuild of `provider-example` needed, and the CLI stays in sync with the daemon.
+- Requires explicit `snap connect` steps for both the content and D-Bus interfaces.
+  Auto-connection is only possible if the interface attributes are pre-approved by the Snap Store; do not assume this happens automatically.
+- Decouples your snap's release cadence from `fpgad`'s.
+
+
+
+
+## Option 2: `stage-snaps` (direct binary staging)
+
+`stage-snaps` pulls the built, published `fpgad` snap apart at build time and lets you copy `cli/fpgad_cli` straight into your own snap.
+No `snap connect` step is required at install/runtime because the binary ships inside your snap.
+
+Be aware that this approach can let `fpgad_cli` drift out of sync with the `fpgad` daemon version actually installed on the user's system, since the CLI binary is frozen at your build time while the daemon may be refreshed independently.
+Prefer Option 1 unless you have a specific reason to pin the CLI binary (e.g. you need a guaranteed-available binary with no runtime connect step).
+
+Example `snapcraft.yaml` for a consumer snap (`provider-example`):
+
+```yaml
+name: provider-example
+# ...
+
+plugs:
+  fpgad-dbus:
+    interface: dbus
+    bus: system
+    name: com.canonical.fpgad
+
+parts:
+  fpgad-cli-binary:
+    plugin: nil
+    stage-snaps:
+      - fpgad
+    stage:
+      - cli/fpgad_cli
+    organize:
+      cli/fpgad_cli: bin/fpgad_cli
+    override-prime: |
+      craftctl default
+      chmod +x $CRAFT_PRIME/bin/fpgad_cli
+
+apps:
+  provider-example:
+    command: bin/fpgad_cli
+    plugs:
+      - fpgad-dbus # fpgad_cli talks to the fpgad daemon over dbus, see below
+```
+
+`fpgad_cli` itself communicates with the `fpgad` daemon over D-Bus (`com.canonical.fpgad` on the system bus — the same interface `fpgad`'s own `cli-dbus` plug uses, see [`snapcraft.yaml:61-65`](snapcraft.yaml)), so your app still needs a matching `dbus` plug connected to the running `fpgad` daemon's `daemon-dbus` slot:
+
+```shell
+sudo snap connect provider-example:fpgad-dbus fpgad:daemon-dbus
+```
+
+Notes:
+
+- The binary is pinned to whatever revision of `fpgad` was available when you built your snap.
+  It will **not** pick up updates automatically when the `fpgad` snap is refreshed on a user's system.
+  You must rebuild/republish `provider-example` to pick up a newer `fpgad_cli`, and until you do, the CLI and daemon versions may not match.
+- You are responsible for tracking which channel/revision of `fpgad` you build against.
+- Simpler to reason about: no plug/slot wiring for the binary itself, only the D-Bus plug is needed at runtime.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,6 +52,12 @@ slots:
     interface: dbus
     bus: system
     name: com.canonical.fpgad
+  fpgad-cli-app:
+    interface: content
+    content: fpgad-cli-content
+    source:
+      read:
+        - $SNAP/cli
 plugs:
   cli-dbus:
     interface: dbus
@@ -73,7 +79,7 @@ plugs:
       - /run/dfx-mgrd.socket
 apps:
   fpgad:
-    command: bin/fpgad_cli
+    command: cli/fpgad_cli
     completer: share/bash-completion/completions/fpgad_cli
     plugs:
       - cli-dbus
@@ -123,6 +129,8 @@ parts:
     rust-path:
       - cli
     rust-channel: 'stable'
+    organize:
+      bin/fpgad_cli: cli/fpgad_cli
   cli-completions:
     after:
       - cli
@@ -130,7 +138,7 @@ parts:
     override-build: |
       craftctl default
       mkdir -p "$CRAFT_PART_INSTALL/share/bash-completion/completions"
-      "$CRAFT_STAGE/bin/fpgad_cli" completions bash \
+      "$CRAFT_STAGE/cli/fpgad_cli" completions bash \
         > "$CRAFT_PART_INSTALL/share/bash-completion/completions/fpgad_cli"
   daemon:
     plugin: rust
@@ -142,6 +150,7 @@ parts:
     plugin: nil
     stage-packages:
       - dfx-mgr
+    # TODO(Sinan): Try using $SNAP_DATA here? Might work!
     override-stage: |
       craftctl default
       cat << 'EOF' > daemon.conf
@@ -155,6 +164,11 @@ parts:
       # move everything, including the staged packages
       "*": (component/dfx-mgr)
       daemon.conf: (component/dfx-mgr)
+  cli_wrapper:
+    plugin: dump
+    source: snap/wrapper
+    organize:
+      "fpgad_cli_wrapper.py": wrapper/fpgad_cli_wrapper.py
   test:
     plugin: dump
     source: tests
@@ -197,6 +211,7 @@ parts:
     source: scripts
     organize:
       "test_wrapper.sh": bin/test_wrapper.sh
+# TODO(Artie/Sinan): This might not be necessary any more (since changing upstream and conf dir)
 layout:
   # For dfx-mgr configuration files (when component is installed)
   /etc/dfx-mgrd:

--- a/snap/wrapper/fpgad_cli_wrapper.py
+++ b/snap/wrapper/fpgad_cli_wrapper.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+
+
+def _print_setup_error(snap_root: str | None, cli_path: str) -> None:
+    print("Error: unable to find executable fpgad_cli for this snap.", file=sys.stderr)
+    if not snap_root:
+        print(
+            "- SNAP is not set (this usually means the script is running outside snap runtime).",
+            file=sys.stderr,
+        )
+    print(f"- Expected path: {cli_path}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Install and connect the required pieces:", file=sys.stderr)
+    print("  snap install fpgad", file=sys.stderr)
+    print("  snap install fpgad+<component_name>", file=sys.stderr)
+    print(
+        "  snap connect <your_snap>:fpgad-cli-app fpgad:fpgad-cli-content",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print(
+        "If your local snap instance name differs, adjust the left-hand side of the connect command.",
+        file=sys.stderr,
+    )
+
+
+def main() -> int:
+    snap_root = os.environ.get("SNAP")
+    cli_path = (
+        os.path.join(snap_root, "fpgad", "cli", "fpgad_cli")
+        if snap_root
+        else "$SNAP/fpgad/cli/fpgad_cli"
+    )
+
+    if snap_root and os.path.isfile(cli_path) and os.access(cli_path, os.X_OK):
+        # Pass through all arguments and return the wrapped command exit status.
+        completed = subprocess.run([cli_path, *sys.argv[1:]], check=False)
+        return completed.returncode
+
+    _print_setup_error(snap_root, cli_path)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/snap_testing/common/base_test.py
+++ b/tests/snap_testing/common/base_test.py
@@ -141,7 +141,7 @@ class FPGATestBase(unittest.TestCase):
         # When running in snap, call the CLI binary directly
         # The alias 'fpgad' points to the CLI app, but inside snap we need the actual binary
         if os.getenv("SNAP"):
-            cmd = [f"{os.getenv('SNAP')}/bin/fpgad_cli"] + args
+            cmd = [f"{os.getenv('SNAP')}/cli/fpgad_cli"] + args
         else:
             cmd = ["fpgad"] + args
 


### PR DESCRIPTION
Based on discussions with Snapd team and FE team, seems like staging a wrapper is a good solution.