### PR TITLE
feat: Add tab completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +258,7 @@ name = "fpgad_cli"
 version = "0.4.1"
 dependencies = [
  "clap",
+ "clap_complete",
  "env_logger",
  "log",
  "tokio",
@@ -685,7 +695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
 
 [[package]]
 name = "fpgad"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "env_logger",
  "fdt",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "fpgad_cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "fpgad_macros"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["daemon", "cli", "fpgad_macros"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "GPL-3.0"
 homepage = "https://github.com/canonical/fpgad"
@@ -11,7 +11,7 @@ repository = "https://github.com/canonical/fpgad"
 authors = ["Talha Can Havadar <talha.can.havadar@canonical.com>", "Artie Poole <stuart.poole@canonical.com>"]
 
 [workspace.dependencies]
-fpgad_macros = { version = "0.4.1", path = "fpgad_macros" }
+fpgad_macros = { version = "0.4.2", path = "fpgad_macros" }
 
 [profile.release]
 opt-level = "z"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5.41", default-features = false, features = ["std", "derive", "help", "usage", "error-context"] }
+clap_complete = { version = "4.5.41", default-features = false }
 env_logger = { version = "0.11.8", default-features = false }
 log = "0.4.27"
 tokio = { version = "1.47.0", default-features = false, features = ["rt-multi-thread", "macros", "sync"] }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -424,27 +424,35 @@ pub enum XlnxSysSubcommand {
 ///
 /// ```shell
 /// # Load a bitstream to a specific device
+///
 /// fpgad --device=fpga0 load bitstream /lib/firmware/design.bit.bin
 ///
 /// # Load an overlay with platform override
+///
 /// fpgad --platform=xlnx-sys load overlay /lib/firmware/overlay.dtbo --name=my_overlay
 ///
 /// # Set flags for a device
+///
 /// fpgad --device=fpga0 set flags 0
 ///
 /// # Get status for all devices
+///
 /// fpgad status
 ///
 /// # Remove an overlay by name
+///
 /// fpgad remove overlay --name=my_overlay
 ///
 /// # Read FPGA flags via xlnx_sys interface
+///
 /// fpgad xlnx-sys read read_flags fpga0
 ///
 /// # Write flags via xlnx_sys interface
+///
 /// fpgad xlnx-sys write write_flags fpga0 0x20
 ///
 /// # Invoke dfx-mgr-client
+///
 /// fpgad dfx-mgr "-listPackage"
 /// ```
 #[derive(Subcommand, Debug)]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -212,8 +212,8 @@ use clap::{Parser, Subcommand};
 ///
 /// ```
 #[derive(Parser, Debug)]
-#[command(name = "fpga")]
-#[command(bin_name = "fpga")]
+#[command(name = "fpgad")]
+#[command(bin_name = "fpgad")]
 pub struct Cli {
     /// Platform override string (bypasses platform detection logic).
     /// When provided, this platform string is passed directly to the daemon
@@ -508,5 +508,21 @@ pub enum Commands {
         /// ```
         #[arg(allow_hyphen_values = true, num_args = 1.., value_name = "CMD")]
         cmd: Vec<String>,
+    },
+    /// Generate a shell completion script and print it to stdout.
+    ///
+    /// This is primarily used at packaging time (the snap wires the generated bash
+    /// script up via the `completer` keyword), but it can also be sourced manually:
+    ///
+    /// ```shell
+    /// # Enable completions for the current shell session
+    /// source <(fpgad completions bash)
+    ///
+    /// # Or install them permanently for the current user
+    /// fpgad completions bash > ~/.local/share/bash-completion/completions/fpgad
+    /// ```
+    Completions {
+        /// Shell to generate the completion script for (e.g. `bash`, `zsh`, `fish`).
+        shell: clap_complete::Shell,
     },
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -35,6 +35,8 @@ use std::error::Error;
 ///    - `status_handler` for querying device status
 ///    - `xlnx_sys_handler` for low-level property read/write via the xlnx_sys interface
 ///    - `dfx_mgr_handler` for passing commands to dfx-mgr-client
+///    - shell-completion generation (`completions <shell>`) is handled inline and
+///      short-circuits before any DBus interaction
 /// 4. Prints success messages or logs errors
 ///
 /// # Returns
@@ -58,6 +60,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
     let cli = Cli::parse();
     debug!("parsed cli command with {cli:#?}");
+
+    // Shell-completion generation is a local, side-effect-free operation: handle it
+    // before any attempt to talk to the daemon over DBus and exit early.
+    if let Commands::Completions { shell } = cli.command() {
+        let mut cmd = <Cli as clap::CommandFactory>::command();
+        let bin_name = cmd.get_name().to_string();
+        clap_complete::generate(*shell, &mut cmd, bin_name, &mut std::io::stdout());
+        return Ok(());
+    }
+
     let result = match cli.command() {
         Commands::Load { command } => load_handler(cli.platform(), cli.device(), command).await,
         Commands::Remove { command } => remove_handler(cli.platform(), cli.device(), command).await,
@@ -67,6 +79,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Commands::Status => status_handler(cli.platform(), cli.device()).await,
         Commands::XlnxSys { command } => xlnx_sys_handler(command).await,
         Commands::DfxMgr { cmd } => dfx_mgr_handler(cmd).await,
+        // Handled above, before any DBus interaction.
+        Commands::Completions { .. } => unreachable!(),
     };
     match result {
         Ok(msg) => {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,6 +74,7 @@ plugs:
 apps:
   fpgad:
     command: bin/fpgad_cli
+    completer: share/bash-completion/completions/fpgad_cli
     plugs:
       - cli-dbus
     aliases:
@@ -122,6 +123,15 @@ parts:
     rust-path:
       - cli
     rust-channel: 'stable'
+  cli-completions:
+    after:
+      - cli
+    plugin: nil
+    override-build: |
+      craftctl default
+      mkdir -p "$CRAFT_PART_INSTALL/share/bash-completion/completions"
+      "$CRAFT_STAGE/bin/fpgad_cli" completions bash \
+        > "$CRAFT_PART_INSTALL/share/bash-completion/completions/fpgad_cli"
   daemon:
     plugin: rust
     source: .


### PR DESCRIPTION
Clap has a way to generate tab completion data - this is then used for snaps.
The one complication is that the binary is called "fpgad_cli" but the bin name is set to "fpgad" so that it works for the snap - since the CLI is what is called by `fpgad load ...` when installed as a snap