### PR TITLE
root: snapcraft.yaml - remove cli alias due to snapcraft changes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,8 +77,6 @@ apps:
     completer: share/bash-completion/completions/fpgad_cli
     plugs:
       - cli-dbus
-    aliases:
-      - cli
   daemon:
     command: bin/fpgad
     daemon: dbus


### PR DESCRIPTION
snapcraft.io dashboard shows:
"DEPRECATED: support for using 'aliases' in the yaml is being removed and will
 be replaced with snap declarations. Please request a snap declaration via the
  forum. lint-snap-v2_alias_valid (fpgad, cli)"

https://forum.snapcraft.io/t/process-for-reviewing-aliases-auto-connections-and-track-requests/455